### PR TITLE
Implement help modal

### DIFF
--- a/v2.0/app/components/GuideModal/guide-jss.js
+++ b/v2.0/app/components/GuideModal/guide-jss.js
@@ -1,0 +1,17 @@
+const styles = theme => ({
+  root: {
+    padding: 0,
+    overflow: 'hidden'
+  },
+  rootContent: {
+    padding: 0,
+    paddingTop: '0 !important',
+    overflow: 'hidden',
+    margin: 20
+  },
+  button: {
+    margin: 15,
+  }
+});
+
+export default styles;

--- a/v2.0/app/components/GuideModal/index.js
+++ b/v2.0/app/components/GuideModal/index.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import Slide from '@material-ui/core/Slide';
+import VideoLibraryIcon from '@material-ui/icons/VideoLibrary';
+import AssignmentIcon from '@material-ui/icons/Assignment';
+import styles from './guide-jss';
+
+function Transition(props) {
+  return <Slide direction="up" {...props} />;
+}
+
+class GuideModal extends React.Component {
+  handleClose = () => {
+    const { closeGuide } = this.props;
+    closeGuide();
+  }
+
+  render() {
+    const {
+      classes,
+      openGuide,
+      closeGuide
+    } = this.props;
+
+    return (
+      <Dialog
+        TransitionComponent={Transition}
+        keepMounted
+        open={openGuide}
+        onClose={closeGuide}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+        className={classes.root}
+      >
+        <DialogContent className={classes.rootContent}>
+          <Typography variant="h4" align="center">Need Help?</Typography>
+          <Typography variant="body1" align="center">We have a variety of resources.</Typography>
+          <Button className={classes.button}
+            href="https://docs.google.com/document/d/1ymEMIofhlk7gwsu46cjjm-ZSeY6thANXO_zaloKBFLg/edit?usp=sharing" target="_blank">
+            <AssignmentIcon /> &nbsp; Written Guides
+          </Button>
+          <Button className={classes.button}
+            href="https://docs.google.com/document/d/16WXJ4VLdhgdP5e-2g2GFkX-PL8g3HlUz0h3AJNYT9vQ/edit?usp=sharing" target="_blank">
+            <VideoLibraryIcon /> &nbsp; Video Tutorials
+          </Button>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}
+
+GuideModal.propTypes = {
+  openGuide: PropTypes.bool.isRequired,
+  closeGuide: PropTypes.func.isRequired,
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles, { withTheme: true })(GuideModal);

--- a/v2.0/app/components/Header/Header.js
+++ b/v2.0/app/components/Header/Header.js
@@ -10,6 +10,7 @@ import Fab from '@material-ui/core/Fab';
 import Ionicon from 'react-ionicons';
 import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
+import Button from '@material-ui/core/Button';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import MenuIcon from '@material-ui/icons/Menu';
@@ -172,7 +173,7 @@ class Header extends React.Component {
           </Fab>
           <Hidden smDown>
             <div className={classes.headerProperties}>
-              <div className={classNames(classes.headerAction, showTitle && classes.fadeOut)}>
+              <div className={classNames(classes.headerAction, showTitle && classes.leftMargin)}>
                 {fullScreen ? (
                   <Tooltip title="Exit Full Screen" placement="bottom">
                     <IconButton className={classes.button} onClick={this.closeFullScreen}>
@@ -191,11 +192,9 @@ class Header extends React.Component {
                     <Ionicon icon="ios-bulb-outline" />
                   </IconButton>
                 </Tooltip>
-                <Tooltip title="Show Guide" placement="bottom">
-                  <IconButton className={classes.button} onClick={openGuide}>
-                    <Ionicon icon="ios-help-circle-outline" />
-                  </IconButton>
-                </Tooltip>
+                <Button className={classes.button} onClick={openGuide}>
+                  <Ionicon icon="ios-help-circle-outline" /> &nbsp; Need Help?
+                </Button>
               </div>
               <Typography component="h2" className={classNames(classes.headerTitle, showTitle && classes.show)}>
                 {title}

--- a/v2.0/app/components/Header/header-jss.js
+++ b/v2.0/app/components/Header/header-jss.js
@@ -398,7 +398,7 @@ const styles = theme => ({
       display: 'inherit'
     }
   },
-  button: {},
+  button: {color: theme.palette.common.white},
   headerProperties: {
     overflow: 'hidden',
     position: 'relative',
@@ -409,6 +409,7 @@ const styles = theme => ({
   },
   fadeOut: {},
   invert: {},
+  leftMargin: {},
   headerAction: {
     margin: `0 ${theme.spacing.unit * 3}px`,
     transition: 'opacity 0.5s ease',
@@ -422,6 +423,10 @@ const styles = theme => ({
     },
     '&$fadeOut': {
       opacity: 0,
+      },
+    '&$leftMargin': {
+        marginLeft: 200,
+        transition: 'all 0.2s ease-in-out'
     },
     '&$invert': {
       '& $button': {

--- a/v2.0/app/components/index.js
+++ b/v2.0/app/components/index.js
@@ -8,6 +8,7 @@ export PapperBlock from './PapperBlock/PapperBlock';
 export SearchUi from './Search/SearchUi';
 // Guide
 export GuideSlider from './GuideSlider';
+export GuideModal from './GuideModal';
 // Form
 export LoginForm from './Forms/LoginForm';
 export FloatingPanel from './Panel/FloatingPanel';

--- a/v2.0/app/containers/Templates/Dashboard.js
+++ b/v2.0/app/containers/Templates/Dashboard.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
-import { GuideSlider } from 'dan-components';
+import { GuideModal } from 'dan-components';
 import { toggleAction, openAction, playTransitionAction } from 'dan-actions/UiActions';
 import LeftSidebarLayout from './layouts/LeftSidebarLayout';
 import RightSidebarLayout from './layouts/RightSidebarLayout';
@@ -74,7 +74,7 @@ class Dashboard extends React.Component {
           )
         }
       >
-        <GuideSlider openGuide={openGuide} closeGuide={this.handleCloseGuide} />
+        <GuideModal openGuide={openGuide} closeGuide={this.handleCloseGuide} />
         { /* Left Sidebar Layout */
           layout === 'left-sidebar' && (
             <LeftSidebarLayout


### PR DESCRIPTION
Now, the header button that used to bring up a modal with dummy tutorial content contains links to both the written instructions table of contents Google Doc and the video tutorial table of contents Google Doc. Also added the text "Need Help?" next to the button and made the header buttons not disappear on a scroll down, but rather slide over nicely to make space for the title, so they can be accessed at all times.