### PR TITLE
Customizable subtitles in Home Page for Impact graphs, Featured Events

### DIFF
--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Actions/AllActions.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Actions/AllActions.js
@@ -27,7 +27,8 @@ class AllActions extends React.Component {
       columns: this.getColumns(),
       loading: true,
       allActions: [],
-      data: []
+      data: [],
+      error: null,
     };
   }
 
@@ -36,7 +37,10 @@ class AllActions extends React.Component {
     const allActionsResponse = await apiCall('/actions.listForCommunityAdmin');
     if (allActionsResponse && allActionsResponse.success) {
       loadAllActions(allActionsResponse.data);
-      await this.setStateAsync({ loading: false, allActions: allActionsResponse.data, data: this.fashionData(allActionsResponse.data) });
+      await this.setStateAsync({ loading: false, error: null, allActions: allActionsResponse.data, data: this.fashionData(allActionsResponse.data) });
+    }
+    else if (allActionsResponse && !allActionsResponse.success) {
+      await this.setStateAsync({loading: false, error: allActionsResponse.error})
     }
   }
 
@@ -193,10 +197,13 @@ class AllActions extends React.Component {
     const title = brand.name + ' - All Actions';
     const description = brand.desc;
     const { classes } = this.props;
-    const { columns, loading, data } = this.state;
+    const { columns, loading, data, error } = this.state;
 
     if (loading) {
       return <LinearBuffer />;
+    }
+    else if (error) {
+      return <div><h2>"Error"</h2></div>;
     }
 
     const options = {

--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Actions/EditActionForm.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Actions/EditActionForm.js
@@ -182,7 +182,7 @@ class CreateNewActionForm extends Component {
                   {
                     name: 'community',
                     label: 'Primary Community',
-                    placeholder: 'eg. Wayland',
+                    placeholder: '',
                     fieldType: 'Dropdown',
                     defaultValue: action.community && '' + action.community.id,
                     dbName: 'community_id',

--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Pages/Home.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Pages/Home.js
@@ -149,7 +149,7 @@ class HomePageEditForm extends Component {
               placeholder: 'eg. Energize Springfield is a volunteer led effort started in 2020',
               fieldType: 'TextField',
               contentType: 'text',
-              isRequired: true,
+              isRequired: false,
               defaultValue: `${homePageData.description}`,
               dbName: 'description',
               readOnly: false

--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Pages/Home.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Pages/Home.js
@@ -207,6 +207,17 @@ class HomePageEditForm extends Component {
                 valueToCheck: 'true',
                 fields: [
                   {
+                    name: 'featured_stats_description',
+                    label: 'Sub-title shown for summary stats',
+                    placeholder: 'eg. Help Us Meet Our Goals',
+                    fieldType: 'TextField',
+                    contentType: 'text',
+                    isRequired: false,
+                    defaultValue: `${homePageData.featured_stats_description}`,
+                    dbName: 'featured_stats_description',
+                    readOnly: false
+                  },
+                  {
                     name: 'attained_number_of_actions',
                     label: 'Manual Input: Attained Number of Actions',
                     placeholder: 'eg. 100',
@@ -329,6 +340,17 @@ class HomePageEditForm extends Component {
               child: {
                 valueToCheck: 'true',
                 fields: [
+                  {
+                    name: 'featured_events_description',
+                    label: 'Subtitle shown for selected events',
+                    placeholder: 'eg. Upcoming Events and Campaigns',
+                    fieldType: 'TextField',
+                    contentType: 'text',
+                    isRequired: false,
+                    defaultValue: `${homePageData.featured_events_description}`,
+                    dbName: 'featured_events_description',
+                    readOnly: false
+                  },
                   {
                     name: 'featured_events',
                     label: 'Select which events to show up on the home Page',

--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Pages/Home.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Pages/Home.js
@@ -118,21 +118,35 @@ class HomePageEditForm extends Component {
           label: 'Welcome Title and Pictures',
           fieldType: 'Section',
           children: [
-            // {
-            //   name: 'title',
-            //   label: 'Main Title',
-            //   placeholder: 'eg. Welcome to Wayland!',
-            //   fieldType: 'TextField',
-            //   contentType: 'text',
-            //   isRequired: true,
-            //   defaultValue: `${homePageData.title}`,
-            //   dbName: 'title',
-            //   readOnly: false
-            // },
             {
-              name: 'description',
+              /* this won't show by default but be the tab title */
+              name: 'title',
+              label: 'Main Title: Displayed on browser tab',
+              placeholder: 'e.g. Energize Springfield',
+              fieldType: 'TextField',
+              contentType: 'text',
+              isRequired: false,
+              defaultValue: `${homePageData.title}`,
+              dbName: 'title',
+              readOnly: false
+            },
+            {
+              /* this is the main tagline (which used to be called 'description' */
+              name: 'sub-title',
               label: 'Welcome Text: Displayed right below the three images',
               placeholder: 'eg. Join our effort to fight climate risks ...',
+              fieldType: 'TextField',
+              contentType: 'text',
+              isRequired: true,
+              defaultValue: `${homePageData.sub_title}`,
+              dbName: 'sub_title',
+              readOnly: false
+            },
+            {
+              /* this is now a description which can show on hover */
+              name: 'description',
+              label: 'Additional description, shown on hover or "more info"',
+              placeholder: 'eg. Energize Springfield is a volunteer led effort started in 2020',
               fieldType: 'TextField',
               contentType: 'text',
               isRequired: true,
@@ -207,9 +221,20 @@ class HomePageEditForm extends Component {
                 valueToCheck: 'true',
                 fields: [
                   {
-                    name: 'featured_stats_description',
-                    label: 'Sub-title shown for summary stats',
+                    name: 'featured_stats_subtitle',
+                    label: 'Custom title shown for summary stats (optional)',
                     placeholder: 'eg. Help Us Meet Our Goals',
+                    fieldType: 'TextField',
+                    contentType: 'text',
+                    isRequired: false,
+                    defaultValue: `${homePageData.featured_stats_subtitle}`,
+                    dbName: 'featured_stats_subtitle',
+                    readOnly: false
+                  },
+                  {
+                    name: 'featured_stats_description',
+                    label: 'Additional information for goals and stats (optional)',
+                    placeholder: '',
                     fieldType: 'TextField',
                     contentType: 'text',
                     isRequired: false,
@@ -341,9 +366,20 @@ class HomePageEditForm extends Component {
                 valueToCheck: 'true',
                 fields: [
                   {
-                    name: 'featured_events_description',
-                    label: 'Subtitle shown for selected events',
+                    name: 'featured_events_subtitle',
+                    label: 'Custom title shown for selected events section (optional)',
                     placeholder: 'eg. Upcoming Events and Campaigns',
+                    fieldType: 'TextField',
+                    contentType: 'text',
+                    isRequired: false,
+                    defaultValue: `${homePageData.featured_events_subtitle}`,
+                    dbName: 'featured_events_subtitle',
+                    readOnly: false
+                  },
+                  {
+                    name: 'featured_events_description',
+                    label: 'Additional information for selected events section (optional)',
+                    placeholder: '',
                     fieldType: 'TextField',
                     contentType: 'text',
                     isRequired: false,


### PR DESCRIPTION
Frontend-portal issue 495 - allows customization of subtitles on Impact graphs and Featured Events.
Also can add information on Goals shown on hover
Also Home page subtitle (tagline) under picture will be taken from sub_title, not description, and description can be used for additional information shown on hover.

Also fix to an infinite spinner error in AllActions page.

These go with the API PR https://github.com/massenergize/api/pull/229
and the frontend-portal PR https://github.com/massenergize/frontend-portal/pull/503