### PR TITLE
Teams issues: Admin 373 and 297

### DIFF
--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Teams/CreateNewTeamForm.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Teams/CreateNewTeamForm.js
@@ -34,16 +34,15 @@ class CreateNewTeamForm extends Component {
     super(props);
     this.state = {
       communities: [],
-      formJson: null
+      formJson: null,
     };
   }
 
 
   async componentDidMount() {
     const communitiesResponse = await apiCall('/communities.listForCommunityAdmin');
-
     if (communitiesResponse && communitiesResponse.data) {
-      const communities = communitiesResponse.data.map(c => ({ ...c, displayName: c.name }));
+      const communities = communitiesResponse.data.map(c => ({ ...c, displayName: c.name, id: '' + c.id }));
       await this.setStateAsync({ communities });
     }
 
@@ -81,13 +80,32 @@ class CreateNewTeamForm extends Component {
               readOnly: false
             },
             {
-              name: 'community',
+              name: 'primary_community',
               label: 'Primary Community',
-              placeholder: 'eg. Wayland',
+              placeholder: '',
               fieldType: 'Dropdown',
               defaultValue: null,
-              dbName: 'community_id',
+              dbName: 'primary_community_id',
               data: [{displayName:"--", id:""}, ...communities],
+            },
+            {
+              name: 'communities',
+              label: 'Communities which share this team',
+              placeholder: '',
+              fieldType: 'Checkbox',
+              selectMany: true,
+              defaultValue: null,
+              dbName: 'communities',
+              data: communities,
+            },
+            {
+              name: 'parent',
+              label: 'Parent Team (must be in the same primary community)',
+              fieldType: 'Dropdown',
+              defaultValue: null,
+              dbName: 'parent_id',
+              data: [{id: null, displayName: "Please choose a community and save the team.  Then edit it to set a parent team"}],
+              readOnly: true,
             },
             {
               name: 'admin_emails',
@@ -95,10 +113,8 @@ class CreateNewTeamForm extends Component {
               placeholder: 'eg. Provide email of valid registered users eg. teamadmin1@gmail.com, teamadmin2@gmail.com',
               fieldType: 'TextField',
               isRequired: true,
-
               defaultValue: null,
               dbName: 'admin_emails',
-              data: communities
             },
             {
               name: 'tagline',

--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Teams/EditTeam.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Teams/EditTeam.js
@@ -41,31 +41,33 @@ class EditTeam extends Component {
       communities: [],
       formJson: null,
       addTeamAdminJson: null,
-      team: null
+      team: null,
+      parentTeamOptions: false,
     };
   }
 
 
   async componentDidMount() {
     const { id } = this.props.match.params;
+    let parentTeamOptions = "0";    
     const teamResponse = await apiCall('/teams.info', { team_id: id });
     if (teamResponse && teamResponse.data) {
       const team = teamResponse.data;
-      let parentTeamOptions;
-      if (team.community) {
+
+      if (team.primary_community) {
         // const teams = await this.props.callTeamsForNormalAdmin();
-        const teams = await apiCall('/teams.list', { community_id: team.community.id });
+        const teams = await apiCall('/teams.list', { community_id: team.primary_community.id });
         // if other teams have us as a parent, can't set a parent ourselves
         // from that point, can set parent teams that are not ourselves AND don't have parents themselves (i.e. aren't sub-teams)
         const parentTeams = teams.data.filter(_team => _team.parent && _team.parent.id === team.id).length === 0
           && teams.data.filter(_team => ((_team.id !== team.id) && !_team.parent));
         if (parentTeams) {
           parentTeamOptions = parentTeams.map(_team => ({ id: _team.id, displayName: _team.name }));
-          parentTeamOptions.unshift({ id: null, displayName: 'NONE' });
+          parentTeamOptions = [{displayName:"NONE", id:"0"}, ...parentTeamOptions]
         }
         else
         {
-          parentTeamOptions = false;
+          parentTeamOptions = [{displayName:"Team cannot have a parent, because it is a parent of another team", id:"0"}];
         }
       }
       await this.setStateAsync({ team, parentTeamOptions });
@@ -73,7 +75,7 @@ class EditTeam extends Component {
     const communitiesResponse = await apiCall('/communities.listForCommunityAdmin');
 
     if (communitiesResponse && communitiesResponse.data) {
-      const communities = communitiesResponse.data.map(c => ({ ...c, displayName: c.name }));
+      const communities = communitiesResponse.data.map(c => ({ ...c, displayName: c.name, id: '' + c.id }));
       await this.setStateAsync({ communities });
     }
 
@@ -88,8 +90,8 @@ class EditTeam extends Component {
   }
 
   createFormJson = async () => {
-    console.log('createFormJson')
     const { communities, team, parentTeamOptions } = this.state;
+    const selectedCommunities = team.communities ? team.communities.map(e => '' + e.id) : [];
     const formJson = {
       title: 'Edit Team Information',
       subTitle: '',
@@ -123,19 +125,29 @@ class EditTeam extends Component {
               readOnly: false
             },
             {
-              name: 'community',
+              name: 'primary_community',
               label: 'Primary Community',
-              placeholder: 'eg. Wayland',
+              placeholder: '',
               fieldType: 'Dropdown',
-              defaultValue: team.community && team.community.id,
-              dbName: 'community_id',
+              defaultValue: team.primary_community && team.primary_community.id,
+              dbName: 'primary_community_id',
               data: [{displayName:"--", id:""}, ...communities],
             },
             {
+              name: 'communities',
+              label: 'Communities which share this team',
+              placeholder: '',
+              fieldType: 'Checkbox',
+              selectMany: true,
+              defaultValue: selectedCommunities,
+              dbName: 'communities',
+              data: communities,
+            },
+             {
               name: 'parent',
-              label: parentTeamOptions && 'Parent Team'  || 'Parent Team (but this team is the parent of another team already)',
+              label: parentTeamOptions && 'Parent Team (must be in the same primary community)',
               fieldType: 'Dropdown',
-              defaultValue: (team.parent && team.parent.id),
+              defaultValue: (team.parent && team.parent.id) || "0",
               dbName: 'parent_id',
               data: parentTeamOptions,
               readOnly: parentTeamOptions && false || true,


### PR DESCRIPTION
373: Setting a parent team on team creation (not possible until saved with a primary community selected

297: Allow teams to span multiple communities, but iwth one primary community (where team admin enables the other communities)