### PR TITLE
Issue 422 - setting recurring event final date

### DIFF
--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Events/CreateNewEventForm.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Events/CreateNewEventForm.js
@@ -230,6 +230,17 @@ class CreateNewEventForm extends Component {
                       { id: 'fourth', displayName: 'fourth'}
                     ]
                   }, 
+                  {
+                    name: 'final_date',
+                    label: 'Final Date for recurring events, you can specify a final date, otherwise events will recur until cancelled.',
+                    placeholder: 'YYYY-MM-DD',
+                    fieldType: 'DateTime',
+                    contentType: 'text',
+                    isRequired: false,
+                    defaultValue: "none",
+                    dbName: 'final_date',
+                    readOnly: false
+                  },
                 ]
               }
             },

--- a/v2.0/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
+++ b/v2.0/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
@@ -190,7 +190,7 @@ class CreateNewEventForm extends Component {
             },
             {
               name: 'end_date_and_time',
-              label: 'End Date And Time - Note: for recurring events, you can specify a final date w/ end time, otherwise events will recur for 1 year or until cancelled.',
+              label: 'End Date And Time',
               placeholder: 'YYYY-MM-DD HH:MM',
               fieldType: 'DateTime',
               contentType: 'text',
@@ -326,6 +326,17 @@ class CreateNewEventForm extends Component {
                       { id: 'fourth', displayName: 'fourth'}
                     ]
                   }, 
+                  {
+                    name: 'final_date',
+                    label: 'Final Date for recurring events, you can specify a final date, otherwise events will recur until cancelled.  The time is ignored.',
+                    placeholder: 'YYYY-MM-DD',
+                    fieldType: 'DateTime',
+                    contentType: 'text',
+                    isRequired: false,
+                    defaultValue: event.recurring_details && event.recurring_details.final_date ? event.recurring_details.final_date : "none",
+                    dbName: 'final_date',
+                    readOnly: false
+                  },
                 ]
               }
             },


### PR DESCRIPTION
Added a new field to the create/edit event forms, to set a final date for recurring events.
No longer set the end date/time to do this.