### PR TITLE
Log admin out if dormant

### DIFF
--- a/app/containers/App/Application.js
+++ b/app/containers/App/Application.js
@@ -83,7 +83,7 @@ import EventRSVPs from "../MassEnergizeSuperAdmin/Events/EventRSVPs";
 import ThemeModal from "../../components/Widget/ThemeModal";
 import { apiCall, PERMISSION_DENIED } from "../../utils/messenger";
 const THIRTY_MINUTES = 1000 * 60 * 30;
-const TWENTY_THREE_HOURS = 1000 * 60 * 60 * 23;
+const TWENTY_FOUR_HOURS = 1000 * 60 * 60 * 24;
 class Application extends React.Component {
   componentWillMount() {
     this.props.reduxCallCommunities();
@@ -92,7 +92,7 @@ class Application extends React.Component {
     this.props.fetchInitialContent(this.props.auth);
     setTimeout(() => {
       this.runAdminStatusCheck();
-    }, TWENTY_THREE_HOURS);
+    }, TWENTY_FOUR_HOURS);
   }
 
   getCommunityList() {

--- a/app/containers/App/Application.js
+++ b/app/containers/App/Application.js
@@ -83,13 +83,16 @@ import EventRSVPs from "../MassEnergizeSuperAdmin/Events/EventRSVPs";
 import ThemeModal from "../../components/Widget/ThemeModal";
 import { apiCall, PERMISSION_DENIED } from "../../utils/messenger";
 const THIRTY_MINUTES = 1000 * 60 * 30;
+const TWENTY_THREE_HOURS = 1000 * 60 * 60 * 23;
 class Application extends React.Component {
   componentWillMount() {
     this.props.reduxCallCommunities();
   }
   componentDidMount() {
     this.props.fetchInitialContent(this.props.auth);
-    this.runAdminStatusCheck();
+    setTimeout(() => {
+      this.runAdminStatusCheck();
+    }, TWENTY_THREE_HOURS);
   }
 
   getCommunityList() {

--- a/app/containers/App/Application.js
+++ b/app/containers/App/Application.js
@@ -81,19 +81,35 @@ import TeamAdminMessages from "../MassEnergizeSuperAdmin/Messages/TeamAdminMessa
 import TeamMembers from "../MassEnergizeSuperAdmin/Teams/TeamMembers";
 import EventRSVPs from "../MassEnergizeSuperAdmin/Events/EventRSVPs";
 import ThemeModal from "../../components/Widget/ThemeModal";
-
+import { apiCall, PERMISSION_DENIED } from "../../utils/messenger";
+const THIRTY_MINUTES = 1000 * 60 * 30;
 class Application extends React.Component {
   componentWillMount() {
     this.props.reduxCallCommunities();
   }
   componentDidMount() {
     this.props.fetchInitialContent(this.props.auth);
+    this.runAdminStatusCheck();
   }
 
   getCommunityList() {
     const { auth } = this.props;
     const list = (auth && auth.admin_at) || [];
     return list.map((com) => com.id);
+  }
+
+  runAdminStatusCheck() {
+    setInterval(async () => {
+      try {
+        const response = await apiCall("auth.whoami");
+        if (response.success) return;
+
+        if (response.error === PERMISSION_DENIED)
+          return (window.location = "/login");
+      } catch (e) {
+        console.log("ADMIN_SESSION_STATUS_ERROR:", e.toString());
+      }
+    }, THIRTY_MINUTES);
   }
 
   render() {

--- a/app/utils/messenger.js
+++ b/app/utils/messenger.js
@@ -3,7 +3,8 @@
  */
 import qs from 'qs';
 import { API_HOST, IS_CANARY, IS_PROD, IS_LOCAL, CC_HOST } from '../config/constants';
-
+export const PERMISSION_DENIED = "permission_denied"; 
+export const SESSION_EXPIRED = "session_expired";
 /**
  * Handles making a POST request to the backend as a form submission
  * It also adds meta data for the BE to get context on the request coming in.
@@ -61,8 +62,8 @@ export async function apiCall(
     if (relocationPage && json && json.success) {
       window.location.href = relocationPage;
     } else if (!json.success) {
-      if (json.error === 'session_expired' || 
-          json.error === 'permission_denied') {
+      if (json.error === SESSION_EXPIRED || 
+          json.error === PERMISSION_DENIED) {
         window.location.href = '/login';
       } else if (json !== 'undefined') {
         console.log(destinationUrl, json);
@@ -115,7 +116,7 @@ export async function apiCallFile(destinationUrl, dataToSend = {}) {
     // endpoints that return non-JSON data will still send JSONs on errors
     if (contentType && contentType.indexOf('application/json') !== -1) {
       return response.json().then(json => {
-        if (json.error === 'session_expired') {
+        if (json.error === SESSION_EXPIRED) {
           localStorage.removeItem('authUser');
         }
         return json;


### PR DESCRIPTION
Here is another way that will help us check if an admin is logged out on the backend or not.  
When an admin logs on for the first time, we already know they are signed up for at least 24 hours, and then their 24hr stay gets refreshed each time, per request. 
This solution here is still our duck tape solution, but way less expensive. 

Instead of the agreed periodic (30 minutes) `whoami` hits on the backend,
- We simply start a thread to wait for 24hrs when an admin logs in. 
- After this waiting period, then start firing requests every 30 minutes to check the status of the admin. 
- If any of the responses come back negative, we know they have definitely been dormant and logged out on the B.E, so the portal redirects to the login page.

This way, we might just suffer only 1 `whoami` hit to know when an admin is logged out ( best case ) 
As compared to the 49 hits (best case) if we run every 30 minutes from the start 🤣 🤣 🤣 🤣 
