### PR TITLE
no auto refresh after auth error

### DIFF
--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -86,6 +86,7 @@ class App extends React.Component {
   }
 
   requestMassToken = (fireToken) => {
+    this.setState({error:null})
     const me = this;
     const body = { idToken: fireToken };
     apiCall('auth.login', body)
@@ -93,7 +94,7 @@ class App extends React.Component {
         const { error } = res;
         if (error) {
           me.setState({ error, started: false });
-          window.location.href = '/login';
+          // window.location.href = '/login';
           return;
         }
         window.location.href = '/';


### PR DESCRIPTION
Ticket #236 

Login errors used to wipe off after a few seconds 
Like this:
https://user-images.githubusercontent.com/26961591/171606807-2f918f39-ca34-4783-ab4a-3a2110b752d6.mov



But now its stays longer: 
As shown here: 

https://user-images.githubusercontent.com/26961591/171606932-34d41d05-4061-475c-989b-df5cfd60004b.mov

Closes #236 
