### PR TITLE
dragging to reorder works well :ok_hand:

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.css
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.css
@@ -5,6 +5,7 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
+
 }
 .ml-thumb-checkmark {
   display: inline;

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import "./MediaLibrary.css";
 import MLButton from "./shared/components/button/MLButton";
@@ -18,6 +18,7 @@ function MediaLibrary(props) {
     onStateChange,
     images,
     defaultTab,
+    dragToOrder,
   } = props;
 
   const [show, setShow] = useState(openState);
@@ -29,6 +30,10 @@ function MediaLibrary(props) {
   const [currentTab, setCurrentTab] = useState(defaultTab);
   const [files, setFiles] = useState([]); // all files that have been selected from user's device [Schema: {id, file}]
   const [croppedSource, setCroppedSource] = useState();
+  // --------------------------------------------------
+  const oldPosition = useRef(null);
+  const newPosition = useRef(null);
+  // --------------------------------------------------
 
   const finaliseCropping = () => {
     if (!cropLoot) return;
@@ -83,6 +88,16 @@ function MediaLibrary(props) {
 
     return [...isNotThere, ...images];
   };
+
+  const swapPositions = () => {
+    const prev = oldPosition.current;
+    const next = newPosition.current;
+    if (prev === null || next === null) return;
+    const images = [...(imageTray || [])];
+    const image = images.splice(prev, 1)[0];
+    images.splice(next, 0, image);
+    handleSelected(images);
+  };
   return (
     <React.Fragment>
       {show && (
@@ -130,6 +145,11 @@ function MediaLibrary(props) {
             content={imageTray}
             remove={remove}
             multiple={multiple}
+            dragToOrder={dragToOrder}
+            oldPosition={oldPosition}
+            newPosition={newPosition}
+            swapPositions={swapPositions}
+
             // switchToCropping={switchToCropping}
           />
         )}
@@ -148,49 +168,96 @@ function MediaLibrary(props) {
   );
 }
 
-const ImageTray = ({ sourceExtractor, remove, content }) => {
+const ImageTray = ({
+  sourceExtractor,
+  remove,
+  content,
+  dragToOrder,
+  newPosition,
+  oldPosition,
+  swapPositions,
+}) => {
   return (
-    <div
-      style={{
-        display: "flex",
-        flexWrap: "wrap",
-        width: "100%",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      {content.map((img, index) => {
-        const src = sourceExtractor ? sourceExtractor(img) : img.url;
-        return (
-          <React.Fragment key={index.toString()}>
-            <TrayImage
-              src={src}
-              id={img.id}
-              remove={remove}
-              // switchToCropping={switchToCropping}
-            />
-          </React.Fragment>
-        );
-      })}
-    </div>
+    <>
+      {dragToOrder && (
+        <center>
+          <small>
+            Rearrange selected images in your preferred order, by dragging them
+          </small>
+        </center>
+      )}
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          width: "100%",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {content.map((img, index) => {
+          const src = sourceExtractor ? sourceExtractor(img) : img.url;
+          return (
+            <React.Fragment key={index.toString()}>
+              <TrayImage
+                src={src}
+                id={img.id}
+                remove={remove}
+                index={index}
+                setOldPosition={() => (oldPosition.current = index)}
+                setNewPosition={() => (newPosition.current = index)}
+                onDragEnd={() => swapPositions()}
+                dragToOrder={dragToOrder}
+                // switchToCropping={switchToCropping}
+              />
+            </React.Fragment>
+          );
+        })}
+      </div>
+    </>
   );
 };
 
-const TrayImage = ({ src, remove, id }) => (
-  <div className="ml-tray-image">
-    <img src={src} className="ml-preview-image elevate-float" />
-    <small className="ml-prev-el-remove" onClick={() => remove(id)}>
-      Remove
-    </small>
-    {/* <small
+/**
+ *
+ * Component that shows a preview of the image that a user has selected
+ * @returns
+ */
+const TrayImage = ({
+  src,
+  remove,
+  id,
+  setOldPosition,
+  setNewPosition,
+  onDragEnd,
+  dragToOrder,
+}) => {
+  const cssOptions = dragToOrder ? {} : { pointerEvents: "none" };
+  return (
+    <div className="ml-tray-image">
+      <img
+        src={src}
+        className="ml-preview-image elevate-float"
+        style={{ "--mouse-type": "move", ...cssOptions }}
+        draggable
+        onDragStart={() => setOldPosition()}
+        onDragEnter={() => setNewPosition()}
+        onDragOver={(e) => e.preventDefault()}
+        onDragEnd={onDragEnd}
+      />
+      <small className="ml-prev-el-remove" onClick={() => remove(id)}>
+        Remove
+      </small>
+      {/* <small
       className="ml-prev-el-remove"
       style={{ color: "blue" }}
       onClick={() => switchToCropping(id, "library-content")}
     >
       Crop
     </small> */}
-  </div>
-);
+    </div>
+  );
+};
 
 MediaLibrary.propTypes = {
   /**
@@ -270,6 +337,7 @@ MediaLibrary.propTypes = {
    * Determines whether or not cropping should be enabled on images. (That are freshly being uploaded)
    */
   allowCropping: PropTypes.bool,
+  dragToOrder: PropTypes.bool,
 };
 
 MediaLibrary.Button = MLButton;
@@ -291,5 +359,6 @@ MediaLibrary.defaultProps = {
   useAwait: false,
   awaitSeconds: 500,
   allowCropping: true,
+  dragToOrder: true,
 };
 export default MediaLibrary;

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/upload/Upload.css
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/upload/Upload.css
@@ -34,16 +34,17 @@
   margin: 10px;
   border-radius: 5px;
   box-shadow: var(--elevate-float);
-  cursor: pointer;
+  cursor: var(--mouse-type);
+  /* cursor: pointer; */
 }
 /* .ml-preview-element {
   margin: 10px;
 } */
 
-.ml-preview-image:active {
+/* .ml-preview-image:active {
   transform: scale(1.5);
   transition: 0.2s ease-out;
-}
+} */
 .ml-prev-el-remove {
   cursor: pointer;
   color: maroon;


### PR DESCRIPTION
This PR lets you drag images in the order you want to appear on the homepage @BradHN1  

Also works with the ["preserving order"](https://github.com/massenergize/api/pull/548) PR on the api repo


Demo: 

 

https://user-images.githubusercontent.com/26961591/182071885-db02141d-721c-4d46-a110-601e88e9d991.mov

 