### PR TITLE
media library uses tooltip to better communicate issues

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.js
@@ -175,6 +175,7 @@ function MediaLibrary(props) {
   );
 }
 
+// ----------------------------------------------------------
 const ImageTray = ({
   sourceExtractor,
   remove,
@@ -224,6 +225,7 @@ const ImageTray = ({
     </>
   );
 };
+// ----------------------------------------------------------
 
 /**
  *
@@ -362,6 +364,11 @@ MediaLibrary.propTypes = {
    * is true, the image will be reduced to a lower quality before uploading
    */
   maximumImageSize: PropTypes.number,
+
+  /**
+   * A function that should return a tooltip component. 
+   */
+  TooltipWrapper: PropTypes.string
 };
 
 MediaLibrary.Button = MLButton;

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/library modal/MediaLibraryModal.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/library modal/MediaLibraryModal.js
@@ -40,6 +40,7 @@ function MediaLibraryModal({
   maximumImageSize,
   compress,
   compressedQuality,
+  TooltipWrapper,
 }) {
   // const [currentTab, setCurrentTab] = useState(defaultTab);
   const [showSidePane, setShowSidePane] = useState(false);
@@ -214,6 +215,7 @@ function MediaLibraryModal({
             </div>
           </div>
           <Footer
+            TooltipWrapper={TooltipWrapper}
             images={images}
             files={files}
             content={content}
@@ -238,8 +240,13 @@ const Footer = ({
   currentTab,
   cropLoot,
   finaliseCropping,
+  TooltipWrapper,
 }) => {
   const isCropping = currentTab === TABS.CROPPING_TAB;
+  const isUploadTab = currentTab === TABS.UPLOAD_TAB;
+  const tooltipMessageWhenDisabled = isUploadTab
+    ? "Click the upload button to upload first, then you can insert it"
+    : "Select an image from the list to insert";
   const len = content && content.length;
   return (
     <div className="ml-footer">
@@ -282,7 +289,16 @@ const Footer = ({
             }}
             disabled={!len}
           >
-            INSERT {len > 0 ? `(${len})` : ""}
+            {TooltipWrapper ? (
+              <TooltipWrapper
+                title={tooltipMessageWhenDisabled}
+                placement="top"
+              >
+                <span>INSERT {len > 0 ? `(${len})` : ""}</span>
+              </TooltipWrapper>
+            ) : (
+              `INSERT ${len > 0 ? `(${len})` : ""}`
+            )}
           </button>
         )}
       </div>

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/library modal/MediaLibraryModal.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/library modal/MediaLibraryModal.js
@@ -245,7 +245,7 @@ const Footer = ({
   const isCropping = currentTab === TABS.CROPPING_TAB;
   const isUploadTab = currentTab === TABS.UPLOAD_TAB;
   const tooltipMessageWhenDisabled = isUploadTab
-    ? "Click the upload button to upload first, then you can insert it"
+    ? "Click the upload button to upload first, then you can insert your image"
     : "Select an image from the list to insert";
   const len = content && content.length;
   return (

--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/FormMediaLibraryImplementation.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/FormMediaLibraryImplementation.js
@@ -10,7 +10,7 @@ import {
   universalFetchFromGallery,
 } from "../../../redux/redux-actions/adminActions";
 import { apiCall } from "../../../utils/messenger";
-import { Checkbox, FormControlLabel } from "@material-ui/core";
+import { Checkbox, FormControlLabel, Tooltip } from "@material-ui/core";
 import { makeLimitsFromImageArray } from "../../../utils/common";
 import { Link } from "react-router-dom";
 
@@ -89,6 +89,13 @@ export const FormMediaLibraryImplementation = (props) => {
         accept={MediaLibrary.AcceptedFileTypes.Images}
         multiple={false}
         extras={extras}
+        TooltipWrapper={({ children, title, placement }) => {
+          return (
+            <Tooltip title={title} placement={placement || "top"}>
+              {children}
+            </Tooltip>
+          );
+        }}
         {...props}
         loadMoreFunction={loadMoreImages}
       />


### PR DESCRIPTION
Related ticket #721 

Media library now uses tooltip to direct users on what to do 
DEMO 
<img width="479" alt="Screenshot 2022-09-19 at 12 04 10" src="https://user-images.githubusercontent.com/26961591/190974880-78e3a5c4-ab3d-4b83-a5f6-a8c5ce29d3a3.png">

<img width="444" alt="Screenshot 2022-09-19 at 12 07 43" src="https://user-images.githubusercontent.com/26961591/190974994-6b76edad-c227-4f8e-b897-8f0d5fe98e6f.png">


NB: I didnt implement the tooltip directly in the media library because I want the Media library component to stay independent. If implemented it directly in the component, anyone that uses the component would now have to use material-ui/core Tooltip 💀 