### PR TITLE
light documentation and fallback

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
@@ -98,6 +98,17 @@ class EditEventForm extends Component {
       readOnly: false,
     };
   }
+
+  /**
+   * All this needs to happen inside getDerivedState because
+   * We need a lifecycle that runs whenever our props change.
+   * The data we load from the API will always come in late.
+   * That is why this is the best place.
+   *
+   * Summary Of Whats Happening Here:
+   * 1. Find event object (Look inside, already loaded event lists, or check event heap, if none of them have it already, just fetch from API)
+   * 2. Use the object to prefill the formJson and use it to create a form.
+   */
   static getDerivedStateFromProps = (props, state) => {
     const {
       match,
@@ -111,22 +122,25 @@ class EditEventForm extends Component {
       eventsFromOtherCommunities,
       putEventInHeap,
       heap,
-      passedEvent,
+      passedEvent, // In cases where this component is being used as a child component, the event object will be passed here directly
     } = props;
-    const { id } = match.params;
+
+    const { id } = (match && match.params) || {};
 
     var { rescheduledEvent } = state;
 
     rescheduledEvent = exceptions[id] || rescheduledEvent;
     var event;
 
+    // ----------------------------------------------------------------------
     if (!passedEvent) {
-      event = (events || []).find((e) => e.id.toString() === id.toString()); // Search for events from my event list
+      //--- Search for events from my event list
+      event = (events || []).find((e) => e.id.toString() === id.toString());
 
-      // If not found, look inside heap
+      //--- If not found, look inside heap
       if (!event) event = (eventsInHeap || {})[id];
 
-      // If not found look inside list of "other Events"
+      //--- If not found look inside list of "other Events"
       if (!event)
         event = (eventsFromOtherCommunities || []).find(
           (e) => e.id.toString() === id.toString()
@@ -139,13 +153,17 @@ class EditEventForm extends Component {
         );
       };
 
-      // If all local searches fail, just retrieve from backend
+      //--- If all local searches fail, just retrieve from backend
       if (!event) findEventFromBackend({ id, storeEventInHeap });
     } else event = passedEvent;
+    // ----------------------------------------------------------------------
 
     const readOnly = checkIfReadOnly(event, auth);
     const thereIsNothingInEventsExceptionsList = rescheduledEvent === null;
 
+    /** The whole point of this is to make sure all of the following have loaded in,
+     *   before we start creating the form. If all of these values load in,  *"readyToRenderPageFirstTime" will be a positive value
+     */
     const readyToRenderPageFirstTime =
       event &&
       events &&
@@ -155,8 +173,17 @@ class EditEventForm extends Component {
       otherCommunities &&
       otherCommunities.length;
 
+    /**
+     * Now, when all the values needed to create the form are loaded in, we now need to create the form
+     * "jobsDoneDontRunWhatsBelowEverAgain" is setup to always be the inverse value of "readyToRender...". Meaning when "readyToRender..." is true, "jobsDone..." will be false.
+     "state.mounted" is initally always false (will get to that soon). Since the If statement below resolves to false, code below will run. The formJson will be created nicely as well as the other things...
+     * Then after, to ensure that the creation never happens again, there has  to
+     * be a third party that indicates that all the loading processes are done, form is created and that everything is finished here. That is where "state.mounted" comes in.
+     * "state.mounted" is set to true the first time the formJson is created.
+     * This way, even if "getDerivedStateFromProps" is triggered from a props change somewhere down the line, the whole process will terminate here...
+     */
     const jobsDoneDontRunWhatsBelowEverAgain =
-      !readyToRenderPageFirstTime || state.mounted;
+      !readyToRenderPageFirstTime || state.mounted; // state.mounted will only be true when the code below has run at least once!
 
     //--- When this value is true, it means we have been able to load all data needed to show the form, so no need to recreate formJson
     if (jobsDoneDontRunWhatsBelowEverAgain) return null;
@@ -189,7 +216,8 @@ class EditEventForm extends Component {
   };
 
   componentDidMount() {
-    const { id } = this.props.match.params;
+    const { match, passedEvent } = this.props;
+    const { id } = (match && match.params) || passedEvent || {};
     var { event } = this.state;
     const { auth, events, addExceptionsToHeap, heap, exceptions } = this.props;
 
@@ -228,7 +256,15 @@ class EditEventForm extends Component {
 
   render() {
     const { classes } = this.props;
-    const { formJson, readOnly, event } = this.state;
+    const { formJson, readOnly, event, mounted } = this.state;
+
+    if (!event && mounted)
+      return (
+        <p>
+          Sorry, we could not load the event you are looking for. If you are
+          sure your event exists, please report this!
+        </p>
+      );
 
     if (!formJson) return <Loading />;
     return (

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventFullView.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventFullView.js
@@ -331,7 +331,7 @@ function EventFullView(props) {
         </div>
       </Paper>
 
-      <EditEventForm match={{ params: { id: event && event.id } }} passedEvent = {event} />
+      <EditEventForm passedEvent = {event} />
     </div>
   );
 }


### PR DESCRIPTION
- [X] Added a bit of documentation on what is going on in getDerivedStateFromProps 
- [X] Also added a fallback for when loading is actually done, and the event doesn't actually exist to prevent infinite spinner. ( Even though an event that does not exist will be caught in the main EventFullView component before it gets to the editForm) 

Demo

<img width="1196" alt="Screenshot 2023-01-12 at 14 06 53" src="https://user-images.githubusercontent.com/26961591/212038239-86015f22-6567-4e27-b49b-cb4c6d959447.png">


## THEORY ON RECENT BUG
So, I have a theory for what was causing the previous bug that we just fixed. 

Typically, the EditEventForm is setup to collect the id of the event we are looking for from the URL. We do that by collecting the value inside `match.param`  which is only made available because we wrap `EditEventForm`  with `withRouter`.  


Because I know this, when it was time to implement `EditEventForm` as a child component, I tried to manually pass the id into a prop called `match` so that the mechanisms will stay the same. Turns out there is more to `withRouter` than just retrieving and passing url values 🤣  🤣 🤣 (still dont know what more there is though) . That is why everything was flailing around; and that is also why when I separated the use cases and passed the event object directly into the component, now it works consistently.


