### PR TITLE
enter in form wont open library. Library tabs wont stay hidden, & cro…

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.js
@@ -44,7 +44,7 @@ function MediaLibrary(props) {
     const { source } = cropLoot;
     setCropped({ ...(cropped || {}), [source.id.toString()]: croppedSource });
     setCurrentTab(TABS.UPLOAD_TAB);
-    return false
+    return false;
   };
 
   const switchToCropping = (content) => {
@@ -109,7 +109,14 @@ function MediaLibrary(props) {
   return (
     <React.Fragment>
       {show && (
-        <div style={{ position: "fixed", top: 0, left: 0, zIndex: 5 }}>
+        <div
+          style={{
+            position: "fixed",
+            zIndex: "1500",
+            top: 0,
+            left: 0,
+          }}
+        >
           <MediaLibraryModal
             {...props}
             images={preselectDefaultImages()}
@@ -162,15 +169,22 @@ function MediaLibrary(props) {
           />
         )}
 
-        <MediaLibrary.Button
+        <div
           onClick={(e) => {
             e.preventDefault();
             setShow(true);
           }}
-          style={{ borderRadius: 5, marginTop: 20, padding: "15px 40px" }}
+          className={`ml-footer-btn `}
+          style={{
+            "--btn-color": "white",
+            "--btn-background": "green",
+            borderRadius: 5,
+            marginTop: 20,
+            padding: "15px 40px",
+          }}
         >
           {actionText}
-        </MediaLibrary.Button>
+        </div>
       </div>
     </React.Fragment>
   );
@@ -376,9 +390,9 @@ MediaLibrary.propTypes = {
   renderBeforeImages: PropTypes.element,
 
   /**
-   * A function that should return a tooltip component. 
+   * A function that should return a tooltip component.
    */
-  TooltipWrapper: PropTypes.string
+  TooltipWrapper: PropTypes.string,
 };
 
 MediaLibrary.Button = MLButton;
@@ -405,6 +419,6 @@ MediaLibrary.defaultProps = {
   compress: true,
   compressedQuality: IMAGE_QUALITY.MEDIUM.key,
   maximumImageSize: DEFFAULT_MAX_SIZE,
-  renderBeforeImages:null
+  renderBeforeImages: null,
 };
 export default MediaLibrary;

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/library modal/MediaLibraryModal.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/library modal/MediaLibraryModal.js
@@ -194,6 +194,12 @@ function MediaLibraryModal({
               {/* --------------------- TAB HEADER AREA -------------- */}
               <div className="m-tab-header-area">
                 {Tabs.map((tab) => {
+                  // A simple logic to make sure the cropping tab button does not show, until an image is selected by a user to crop. (To reduce confusion)
+                  const imageForCroppingNotSelectedYet =
+                    currentTab !== TABS.CROPPING_TAB &&
+                    tab.key === TABS.CROPPING_TAB;
+                  if (imageForCroppingNotSelectedYet) return <></>;
+
                   const isCurrent = currentTab === tab.key;
                   return (
                     <div


### PR DESCRIPTION
## Related Tickets  #651, #770, #735 

- [X] Media library wont open when you hit enter in the form again 
- [X] Media library tabs wont be hiding under the top bar for smaller screens 
- [X] Cropping tab is hidden until an image is selected to be cropped(cropping already works).

https://user-images.githubusercontent.com/26961591/216893729-0f69d5de-4862-4c1d-9045-5ea5085ff5a1.mov

