### PR TITLE
Fix redirect after login

### DIFF
--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -16,9 +16,22 @@ import {
   reduxCallIdToken,
   reduxLoadAuthAdmin,
 } from "../../redux/redux-actions/adminActions";
-import { LAST_VISITED, TIME_UNTIL_EXPIRATION, TWENTY_FOUR_HOURS } from "../../utils/constants";
+import {
+  LAST_VISITED,
+  TIME_UNTIL_EXPIRATION,
+  TWENTY_FOUR_HOURS,
+} from "../../utils/constants";
 
 window.__MUI_USE_NEXT_TYPOGRAPHY_VARIANTS__ = true;
+
+const saveCurrentLocation = () => {
+  var old = window.localStorage.getItem(LAST_VISITED);
+  var url = window.location.href;
+  if (old === url) return;
+  const canSaveThisURL = !["login", "atf"].find((kw) => url.includes(kw));
+  // Save the last visited url in local storage unless its the login page or dashboard url after login
+  if (canSaveThisURL) window.localStorage.setItem(LAST_VISITED, url);
+};
 
 /*
     1. Collect user Auth user From Firebase
@@ -50,11 +63,15 @@ class App extends React.Component {
       error: null,
       started: false,
     };
-    this.saveCurrentLocation();
     this.signOut = this.signOut.bind(this);
     this.loginWithFacebook = this.loginWithFacebook.bind(this);
     this.loginWithGoogle = this.loginWithGoogle.bind(this);
     this.normalLogin = this.normalLogin.bind(this);
+  }
+
+  static getDerivedStateFromProps(_, __) {
+    saveCurrentLocation();
+    return null;
   }
 
   async componentDidMount() {
@@ -102,7 +119,8 @@ class App extends React.Component {
     this.setState({ error: null });
     const me = this;
     const body = { idToken: fireToken };
-    var successURL = localStorage.getItem(LAST_VISITED) || "/";
+    // var successURL = localStorage.getItem(LAST_VISITED) || "/";
+    var successURL = "/?atf=true"; // atf = Ask to forward
     apiCall("auth.login", body)
       .then((res) => {
         const { error } = res;
@@ -202,13 +220,6 @@ class App extends React.Component {
         });
       });
   };
-
-  saveCurrentLocation() {
-    var url = window.location.href;
-    const canSaveThisURL = !["login"].find((kw) => url.includes(kw));
-    // Save the last visited url in local storage unless its the login page
-    if (canSaveThisURL) window.localStorage.setItem(LAST_VISITED, url);
-  }
 
   render() {
     const { error, started } = this.state;

--- a/app/containers/MassEnergizeSuperAdmin/Summary/ContinueWhereYouLeft.js
+++ b/app/containers/MassEnergizeSuperAdmin/Summary/ContinueWhereYouLeft.js
@@ -14,7 +14,7 @@ function ContinueWhereYouLeft() {
   const startExitTimer = () => {
     setTimeout(() => {
       setSavedURL(null);
-        history.push("/");
+      history.push("/");
     }, WAIT_TIME);
   };
   useEffect(() => {
@@ -48,7 +48,7 @@ function ContinueWhereYouLeft() {
       }}
     >
       <Typography
-        onClick={() => history.push(url)}
+        onClick={() => (window.location.href = url)}
         style={{ border: "dotted 0px black", borderBottomWidth: 2 }}
       >
         <b>

--- a/app/containers/MassEnergizeSuperAdmin/Summary/ContinueWhereYouLeft.js
+++ b/app/containers/MassEnergizeSuperAdmin/Summary/ContinueWhereYouLeft.js
@@ -1,0 +1,64 @@
+import { Typography } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
+import { fetchParamsFromURL } from "../../../utils/common";
+import { LAST_VISITED } from "../../../utils/constants";
+
+const WAIT_TIME = 20000; // 20 seconds
+function ContinueWhereYouLeft() {
+  const [savedURL, setSavedURL] = useState();
+  const host = window.location.host;
+  const url = localStorage.getItem(LAST_VISITED);
+  const history = useHistory();
+
+  const startExitTimer = () => {
+    setTimeout(() => {
+      setSavedURL(null);
+        history.push("/");
+    }, WAIT_TIME);
+  };
+  useEffect(() => {
+    // This value will be available right after login everytime
+    let { atf } = fetchParamsFromURL(window.location, "atf");
+    atf = atf === "true";
+    // If there isnt any saved URL in local storage, dont bother!
+    if (!url) return;
+    // If there is a URL saved, make sure it isnt the same as the dashboard URL
+    const isNotDashboard = url.split(host)[1] !== "/";
+    // If it isnt the same as the dashboard link, then ask tthe user if they want to go back to that page
+    // And start counting down to WAIT_TIME (The notification will be disabled with WAIT_TIME is reached)
+    if (atf && isNotDashboard) {
+      setSavedURL(url);
+      startExitTimer();
+    }
+  }, []);
+
+  if (!savedURL) return <></>;
+
+  return (
+    <div
+      className="touchable-opacity"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        background: "rgb(253 235 222)",
+        color: "black",
+        padding: "15px 20px",
+        marginBottom: 20,
+      }}
+    >
+      <Typography
+        onClick={() => history.push(url)}
+        style={{ border: "dotted 0px black", borderBottomWidth: 2 }}
+      >
+        <b>
+          Looks like you just signed in, want to continue where you last left
+          off?
+        </b>
+      </Typography>{" "}
+      <i style={{ marginLeft: 8 }} className=" fa fa-long-arrow-right" />
+    </div>
+  );
+}
+
+export default ContinueWhereYouLeft;

--- a/app/containers/MassEnergizeSuperAdmin/Summary/NormalAdminHome.js
+++ b/app/containers/MassEnergizeSuperAdmin/Summary/NormalAdminHome.js
@@ -34,6 +34,7 @@ import WhatNext from "./WhatNext";
 import CommunityEngagement from "./CommunityEngagement";
 import Feature from "../../../components/FeatureFlags/Feature";
 import { FLAGS } from "../../../components/FeatureFlags/flags";
+import ContinueWhereYouLeft from "./ContinueWhereYouLeft";
 
 class NormalAdminHome extends PureComponent {
   constructor(props) {
@@ -225,6 +226,8 @@ class NormalAdminHome extends PureComponent {
           <SummaryChart data={summary_data} />
         </Grid>
         <br />
+
+        <ContinueWhereYouLeft />
 
         <Feature
           name={FLAGS.NEW_USER_ENGAGEMENT_VIEW}

--- a/app/containers/MassEnergizeSuperAdmin/Summary/index.js
+++ b/app/containers/MassEnergizeSuperAdmin/Summary/index.js
@@ -156,7 +156,7 @@ class SummaryDashboard extends PureComponent {
           <SummaryChart data={summary_data} />
         </Grid>
         <br />
-
+        <ContinueWhereYouLeft />
         <Feature
           name={FLAGS.NEW_USER_ENGAGEMENT_VIEW}
           fallback={

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -2,7 +2,7 @@ export const RESTART_ON_REMOUNT = "@@saga-injector/restart-on-remount";
 export const DAEMON = "@@saga-injector/daemon";
 export const ONCE_TILL_UNMOUNT = "@@saga-injector/once-till-unmount";
 
-export const LAST_VISITED = "LAST_VISITED";
+export const LAST_VISITED = "LAST_VISITED_URL"; // Changed from LAST_VISITED just to give this a new start when deployed
 export const LOADING = "LOADING";
 export const TWENTY_FOUR_HOURS = 1000 * 60 * 60 * 24;
 export const TIME_UNTIL_EXPIRATION = "TIME_UNTIL_EXPIRATION";


### PR DESCRIPTION
## Related ticket https://github.com/massenergize/frontend-admin/issues/803

- [X] As requested,  now sign in will always take you to the dashboard. 

## But here is the kicker 🤣 🤣 🤣 🤣 🤣 🤣 

We are still tracking all the urls a user visits on the platform. But when you are sent to the dashboard page and your last visited page isnt the same as the dashboard page, you will be shown a nonintrusive notification that will ask you if you want to continue to the page you were last on before you signed in. If you want to, you can click, if not, the notification will go away in 20 seconds. 

### NB: this only happens on dashboard page only right after sign in. Normal browsing and clicking to dashboard page doesnt show you any of this. All behaviour is normal after you have made a choice, or ignored the notification. 

## DEMO 

https://user-images.githubusercontent.com/26961591/220261225-efb5192f-eead-4d25-9fe3-192de113296f.mov

@BradHN1  let me know if the team hates it 🤣 🤣 🤣 💀 

