### PR TITLE
Events Redesign

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -83,16 +83,13 @@ class AllEvents extends React.Component {
         image: d.image,
         initials: `${d.name && d.name.substring(0, 2).toUpperCase()}`,
       },
-      {
-        name: smartString(d.name),
-        is_on_home_page: d.is_on_home_page,
-      },
+      smartString(d.name),
       `${
         smartString(d.tags.map((t) => t.name).join(", "), 30) // limit to first 30 chars
       }`,
       d.is_global ? "Template" : d.community && d.community.name,
       { isLive: d.is_published, item: d },
-      d.id,
+      { id: d.id,  is_on_home_page: d.is_on_home_page},
       d.is_published ? "Yes" : "No",
       d.is_global,
       getHumanFriendlyDate(d.start_date_and_time, true, false),
@@ -148,25 +145,6 @@ class AllEvents extends React.Component {
         key: "name",
         options: {
           filter: false,
-          customBodyRender: (d) => {
-            return (
-              <div>
-                {<span>{d?.name}</span>}
-                {d?.is_on_home_page && (
-                  <Tooltip title="Event is live on community homepage">
-                    <StarsIcon
-                      size="small"
-                      variant="outlined"
-                      color="secondary"
-                      sx={{
-                        fontSize: 19,
-                      }}
-                    />
-                  </Tooltip>
-                )}
-              </div>
-            );
-          },
         },
       },
       {
@@ -218,7 +196,7 @@ class AllEvents extends React.Component {
           filter: false,
           download: false,
           sort: false,
-          customBodyRender: (id) => (
+          customBodyRender: ({ id, is_on_home_page }) => (
             <div style={{ display: "flex" }}>
               <Link to={`/admin/edit/${id}/event`}>
                 <EditIcon
@@ -262,7 +240,10 @@ class AllEvents extends React.Component {
                   />
                 </Link>
               )}
-              <Tooltip title="Add/Remove event to/from community homepage">
+              <Tooltip
+                title={`${is_on_home_page ? "Remove" : "Add"} event ${
+                  is_on_home_page ? "from" : "to" } community's homepage`}
+              >
                 <Link
                   onClick={() => {
                     console.log("clicked");
@@ -274,21 +255,21 @@ class AllEvents extends React.Component {
                     });
                   }}
                 >
-                  <HomeIcon
-                    size="small"
-                    variant="outlined"
-                    sx={{
-                      color: "rgb(65 172 65)",
-                    }}
-                  />
-                  {/* <StarRateIcon
-                    size="small"
-                    variant="outlined"
-                    // color="secondary"
-                    sx={{
-                      color: "rgb(65 172 65)",
-                    }}
-                  /> */}
+                  {is_on_home_page ? (
+                    <HomeIcon
+                      size="small"
+                      variant="outlined"
+                      sx={{
+                        color: "rgb(65 172 65)",
+                      }}
+                    />
+                  ) : (
+                    <HomeIcon
+                      size="small"
+                      variant="outlined"
+                      color={"secondary"}
+                    />
+                  )}
                 </Link>
               </Tooltip>
             </div>

--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -16,6 +16,8 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { apiCall } from "../../../utils/messenger";
 import styles from "../../../components/Widget/widget-jss";
+import StarsIcon from "@mui/icons-material/Stars";
+import Tooltip from "@mui/material/Tooltip";
 import {
   reduxGetAllEvents,
   reduxGetAllCommunityEvents,
@@ -49,6 +51,7 @@ import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import CallMadeIcon from "@mui/icons-material/CallMade";
 import { FROM } from "../../../utils/constants";
 import Loader from "../../../utils/components/Loader";
+import StarRateIcon from "@mui/icons-material/StarRate";
 class AllEvents extends React.Component {
   constructor(props) {
     super(props);
@@ -79,8 +82,13 @@ class AllEvents extends React.Component {
         image: d.image,
         initials: `${d.name && d.name.substring(0, 2).toUpperCase()}`,
       },
-      smartString(d.name), // limit to first 30 chars
-      `${smartString(d.tags.map((t) => t.name).join(", "), 30)}`,
+      {
+        name: smartString(d.name),
+        is_on_home_page: d.is_on_home_page,
+      },
+      `${
+        smartString(d.tags.map((t) => t.name).join(", "), 30) // limit to first 30 chars
+      }`,
       d.is_global ? "Template" : d.community && d.community.name,
       { isLive: d.is_published, item: d },
       d.id,
@@ -139,6 +147,24 @@ class AllEvents extends React.Component {
         key: "name",
         options: {
           filter: false,
+          customBodyRender: (d) => {
+            return (
+              <div>
+                {<span>{d?.name}</span>}
+                {d?.is_on_home_page && (
+                  <StarsIcon
+                    size="small"
+                    variant="outlined"
+                    color="secondary"
+                    sx={{
+                      fontSize: 19,
+                      // marginBottom: 1,
+                    }}
+                  />
+                )}
+              </div>
+            );
+          },
         },
       },
       {
@@ -234,6 +260,27 @@ class AllEvents extends React.Component {
                   />
                 </Link>
               )}
+              {/* {auth && auth.cadmin && ( */}
+              <Tooltip title="Add/Remove event to community homepage">
+                <Link
+                  onClick={() => {
+                    console.log("clicked");
+                    this.props.toggleLive({
+                      show: true,
+                      component: this.addToHomePageUI({ id }),
+                      onConfirm: () => this.addEventToHomePage(id),
+                      closeAfterConfirmation: true,
+                    });
+                  }}
+                >
+                  <StarRateIcon
+                    size="small"
+                    variant="outlined"
+                    color="secondary"
+                  />
+                </Link>
+              </Tooltip>
+              {/* )} */}
             </div>
           ),
         },
@@ -289,7 +336,7 @@ class AllEvents extends React.Component {
     const index = data.findIndex((a) => a.id === item.id);
     item.is_published = !status;
     data.splice(index, 1, item);
-    putInRedux( [...data]);
+    putInRedux([...data]);
     const community = item.community;
     apiCall("/events.update", {
       event_id: item.id,
@@ -311,6 +358,61 @@ class AllEvents extends React.Component {
       </div>
     );
   }
+
+  addToHomePageUI({ id }) {
+    const data = this.props.allEvents || [];
+    let event =
+      data?.find((item) => item.id?.toString() === id?.toString()) || {};
+    return (
+      <div>
+        <Typography>
+          would you like to {event?.is_on_home_page ? "remove" : "add"}{" "}
+          <b>{event?.name}</b> {event?.is_on_home_page ? "from" : "to"}{" "}
+          <b>{event?.community?.name}</b>
+          {"'s "} community homepage?
+        </Typography>
+      </div>
+    );
+  }
+
+  addEventToHomePage = (id) => {
+     const { allEvents, putEventsInRedux } = this.props;
+    const data = allEvents || [];
+    let event =data?.find((item) => item.id?.toString() === id?.toString()) || {};
+    const index = data.findIndex((a) => a.id?.toString() === id);
+
+
+    const toSend = {
+      event_id: id,
+      community_id: event?.community?.id,
+    };
+    if (new Date(event?.start_date_and_time) < Date.now()) {
+      this.props.toggleToast({
+        open: true,
+        message: "Event is out of date",
+        variant: "error",
+      });
+      return;
+    }
+    apiCall("home_page_settings.addEvent", toSend).then((res) => {
+      if (res.success) {
+        event.is_on_home_page = res?.data?.status
+        data.splice(index, 1, event);
+        putEventsInRedux([...data]);
+        this.props.toggleToast({
+          open: true,
+          message: res.data?.msg,
+          variant: res?.data?.msg?.includes("removed") ? "warning" : "success",
+        });
+      } else {
+        this.props.toggleToast({
+          open: true,
+          message: res?.error,
+          variant: "error",
+        });
+      }
+    });
+  };
 
   customSort(data, colIndex, order) {
     const isComparingLive = colIndex === 6;
@@ -347,9 +449,8 @@ class AllEvents extends React.Component {
       });
     });
     const rem = (itemsInRedux || []).filter((com) => !ids.includes(com.id));
-    putEventsInRedux( rem);
+    putEventsInRedux(rem);
   }
-  
 
   fetchOtherEvents() {
     const { community_ids, exclude } = this.state;
@@ -359,9 +460,9 @@ class AllEvents extends React.Component {
     apiCall("/events.others.listForCommunityAdmin", {
       community_ids: ids,
       exclude: exclude || false,
-      limit:getLimit(PAGE_PROPERTIES.ALL_EVENTS.key),
-      params:json.stringify({}),
-      page:1,
+      limit: getLimit(PAGE_PROPERTIES.ALL_EVENTS.key),
+      params: json.stringify({}),
+      page: 1,
     })
       .then((response) => {
         this.setState({ loading: false });
@@ -378,10 +479,16 @@ class AllEvents extends React.Component {
     const description = brand.desc;
     const { columns } = this.state;
     const { classes } = this.props;
-    const { allEvents, putEventsInRedux, auth, meta, putMetaDataToRedux } = this.props;
+    const {
+      allEvents,
+      putEventsInRedux,
+      auth,
+      meta,
+      putMetaDataToRedux,
+    } = this.props;
     const data = this.fashionData(allEvents || []);
     const metaData = meta && meta.events;
-    
+
     const options = {
       filterType: "dropdown",
       responsive: "standard",
@@ -404,12 +511,7 @@ class AllEvents extends React.Component {
           name: "events",
           meta: meta,
         }),
-      customSearchRender: (
-        searchText,
-        handleSearch,
-        hideSearch,
-        options
-      ) => (
+      customSearchRender: (searchText, handleSearch, hideSearch, options) => (
         <SearchBar
           url={getAdminApiEndpoint(auth, "/events")}
           reduxItems={allEvents}
@@ -477,8 +579,7 @@ class AllEvents extends React.Component {
             noTemplates: noTemplatesSelectedGoAhead,
           }),
           onConfirm: () =>
-            noTemplatesSelectedGoAhead &&
-            this.nowDelete({ idsToDelete, data }),
+            noTemplatesSelectedGoAhead && this.nowDelete({ idsToDelete, data }),
           closeAfterConfirmation: true,
           cancelText: noTemplatesSelectedGoAhead
             ? "No"
@@ -489,9 +590,9 @@ class AllEvents extends React.Component {
       },
     };
 
-     if (isEmpty(metaData)) {
-       return <Loader />;
-     }
+    if (isEmpty(metaData)) {
+      return <Loader />;
+    }
 
     return (
       <div>

--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -52,6 +52,7 @@ import CallMadeIcon from "@mui/icons-material/CallMade";
 import { FROM } from "../../../utils/constants";
 import Loader from "../../../utils/components/Loader";
 import StarRateIcon from "@mui/icons-material/StarRate";
+import HomeIcon from "@mui/icons-material/Home";
 class AllEvents extends React.Component {
   constructor(props) {
     super(props);
@@ -152,15 +153,16 @@ class AllEvents extends React.Component {
               <div>
                 {<span>{d?.name}</span>}
                 {d?.is_on_home_page && (
-                  <StarsIcon
-                    size="small"
-                    variant="outlined"
-                    color="secondary"
-                    sx={{
-                      fontSize: 19,
-                      // marginBottom: 1,
-                    }}
-                  />
+                  <Tooltip title="Event is live on community homepage">
+                    <StarsIcon
+                      size="small"
+                      variant="outlined"
+                      color="secondary"
+                      sx={{
+                        fontSize: 19,
+                      }}
+                    />
+                  </Tooltip>
                 )}
               </div>
             );
@@ -260,8 +262,7 @@ class AllEvents extends React.Component {
                   />
                 </Link>
               )}
-              {/* {auth && auth.cadmin && ( */}
-              <Tooltip title="Add/Remove event to community homepage">
+              <Tooltip title="Add/Remove event to/from community homepage">
                 <Link
                   onClick={() => {
                     console.log("clicked");
@@ -273,14 +274,23 @@ class AllEvents extends React.Component {
                     });
                   }}
                 >
-                  <StarRateIcon
+                  <HomeIcon
                     size="small"
                     variant="outlined"
-                    color="secondary"
+                    sx={{
+                      color: "rgb(65 172 65)",
+                    }}
                   />
+                  {/* <StarRateIcon
+                    size="small"
+                    variant="outlined"
+                    // color="secondary"
+                    sx={{
+                      color: "rgb(65 172 65)",
+                    }}
+                  /> */}
                 </Link>
               </Tooltip>
-              {/* )} */}
             </div>
           ),
         },

--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -10,13 +10,10 @@ import { Link, withRouter } from "react-router-dom";
 import Avatar from "@mui/material/Avatar";
 
 import Paper from "@mui/material/Paper";
-import LinearProgress from "@mui/material/LinearProgress";
-import Grid from "@mui/material/Grid";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { apiCall } from "../../../utils/messenger";
 import styles from "../../../components/Widget/widget-jss";
-import StarsIcon from "@mui/icons-material/Stars";
 import Tooltip from "@mui/material/Tooltip";
 import {
   reduxGetAllEvents,
@@ -51,7 +48,6 @@ import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import CallMadeIcon from "@mui/icons-material/CallMade";
 import { FROM } from "../../../utils/constants";
 import Loader from "../../../utils/components/Loader";
-import StarRateIcon from "@mui/icons-material/StarRate";
 import HomeIcon from "@mui/icons-material/Home";
 class AllEvents extends React.Component {
   constructor(props) {

--- a/app/containers/MassEnergizeSuperAdmin/Events/CreateNewEventForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/CreateNewEventForm.js
@@ -551,17 +551,6 @@ const createFormJson = ({
         data: [{ id: "false", value: "No" }, { id: "true", value: "Yes" }],
       },
       {
-        name: "exclude_from_nudge",
-        label:
-          "Would you want to exclude this event from the nudge sent your community Members?",
-        fieldType: "Radio",
-        isRequired: false,
-        defaultValue: "false",
-        dbName: "exclude_from_nudge",
-        readOnly: false,
-        data: [{ id: "false", value: "No" }, { id: "true", value: "Yes" }],
-      },
-      {
         name: "archive",
         label: "Archive this Event",
         fieldType: "Radio",

--- a/app/containers/MassEnergizeSuperAdmin/Events/CreateNewEventForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/CreateNewEventForm.js
@@ -205,6 +205,7 @@ const createFormJson = ({
             // defaultValue: progress.name || "",
             dbName: "name",
             readOnly: false,
+            maxLength: 100, // matches max length in the BE 
           },
           {
             name: "featured_summary",
@@ -251,7 +252,10 @@ const createFormJson = ({
             defaultValue: "false",
             dbName: "is_recurring",
             readOnly: false,
-            data: [{ id: "false", value: "No" }, { id: "true", value: "Yes" }],
+            data: [
+              { id: "false", value: "No" },
+              { id: "true", value: "Yes" },
+            ],
             child: {
               dbName: "recurring_details",
               valueToCheck: "true",
@@ -535,6 +539,27 @@ const createFormJson = ({
             },
           ],
         },
+      },
+      {
+        name: "add_to_home_page",
+        label: "Would you want this Event to be added to your homepage?",
+        fieldType: "Radio",
+        isRequired: false,
+        defaultValue: "false",
+        dbName: "add_to_home_page",
+        readOnly: false,
+        data: [{ id: "false", value: "No" }, { id: "true", value: "Yes" }],
+      },
+      {
+        name: "exclude_from_nudge",
+        label:
+          "Would you want to exclude this event from the nudge sent your community Members?",
+        fieldType: "Radio",
+        isRequired: false,
+        defaultValue: "false",
+        dbName: "exclude_from_nudge",
+        readOnly: false,
+        data: [{ id: "false", value: "No" }, { id: "true", value: "Yes" }],
       },
       {
         name: "archive",

--- a/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
@@ -503,7 +503,10 @@ const createFormJson = ({
             defaultValue: event.is_recurring ? "true" : "false",
             dbName: "is_recurring",
             readOnly: false,
-            data: [{ id: "false", value: "No" }, { id: "true", value: "Yes" }],
+            data: [
+              { id: "false", value: "No" },
+              { id: "true", value: "Yes" },
+            ],
             child: {
               dbName: "recurring_details",
               valueToCheck: "true",
@@ -885,6 +888,17 @@ const createFormJson = ({
             },
           ],
         },
+      },
+      {
+        name: "exclude_from_nudge",
+        label:
+          "Would you want to exclude this event from the nudge sent your community Members?",
+        fieldType: "Radio",
+        isRequired: false,
+        defaultValue: "false",
+        dbName: "exclude_from_nudge",
+        readOnly: false,
+        data: [{ id: "false", value: "No" }, { id: "true", value: "Yes" }],
       },
       {
         name: "archive",

--- a/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
@@ -890,17 +890,6 @@ const createFormJson = ({
         },
       },
       {
-        name: "exclude_from_nudge",
-        label:
-          "Would you want to exclude this event from the nudge sent your community Members?",
-        fieldType: "Radio",
-        isRequired: false,
-        defaultValue: "false",
-        dbName: "exclude_from_nudge",
-        readOnly: false,
-        data: [{ id: "false", value: "No" }, { id: "true", value: "Yes" }],
-      },
-      {
         name: "archive",
         label: "Archive this Event",
         fieldType: "Radio",


### PR DESCRIPTION
####  Summary / Highlights
 Works with [API PR](https://github.com/massenergize/api/pull/661)
Added two fields to the event creation and edit forms to allow admins
-  Exclude events from the nudges 
- Add events to their communities homepage

Added an additional action on all events table to enable admins add/remove events to/from their community's homepage

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
<img width="918" alt="Screenshot 2023-03-22 at 10 19 34 AM" src="https://user-images.githubusercontent.com/42780120/226873282-f595856c-0300-4536-b4d9-b3447ab65104.png">


#### Video Demo

https://user-images.githubusercontent.com/42780120/227510475-d4ee0a45-c900-47d4-87ea-6cb1c9315e82.MP4


#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
