### PR TITLE
Fix: list teams member from Edit team page

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
@@ -1189,7 +1189,6 @@ class MassEnergizeForm extends Component {
       <div key={this.state.refreshKey}>
         <Grid
           container
-          spacing={24}
           alignItems="flex-start"
           direction="row"
           justify="center"


### PR DESCRIPTION
####  Summary / Highlights
This PR fixes the bug on the admin portal that prevents admins from viewing team members on the edit team page.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

https://user-images.githubusercontent.com/42780120/230715894-a4c4dbcf-d26b-49f2-8f32-4453603e80a2.mp4

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [x] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [x] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
