### PR TITLE
commented out old upload button

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/upload/Upload.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/shared/components/upload/Upload.js
@@ -167,29 +167,29 @@ function Upload({
         }}
         onDrop={(e) => handleDroppedFile(e)}
       >
-        {files.length > 0 ? (
-          <>
-            <p>
-              Upload ({files.length}) File
-              {files.length === 1 ? "" : "s"}
-            </p>
-            {uploading ? (
-              <img src={spinner} style={{ height: 70 }} alt="" />
-            ) : (
-              <MLButton
-                style={{
-                  height: "auto",
-                  borderRadius: 4,
-                  padding: "17px 40px",
-                  marginBottom: 5,
-                }}
-                backColor="green"
-                onClick={() => upload()}
-              >
-                UPLOAD
-              </MLButton>
-            )}
-          </>
+        {files.length > 0 ? ( <></>
+          // <>
+          //   <p>
+          //     Upload ({files.length}) File
+          //     {files.length === 1 ? "" : "s"}
+          //   </p>
+          //   {uploading ? (
+          //     <img src={spinner} style={{ height: 70 }} alt="" />
+          //   ) : (
+          //     <MLButton
+          //       style={{
+          //         height: "auto",
+          //         borderRadius: 4,
+          //         padding: "17px 40px",
+          //         marginBottom: 5,
+          //       }}
+          //       backColor="green"
+          //       onClick={() => upload()}
+          //     >
+          //       UPLOAD
+          //     </MLButton>
+          //   )}
+          // </>
         ) : (
           <>
             <img src={uploadDummy} style={{ width: 110, height: 66 }} alt="" />


### PR DESCRIPTION
So initially, I still left the old upload button there to cater for situations where admins just wanted to upload a new image, but still want the dialog to stay open, so that they can go into the list of images and do whatever else (i.e. maybe choose another image if they wanted to).  

But I guess we dont want that 🤣 , so this PR removes the old button. Now there is only one direct button that explicitly says "Upload & Insert" on the footer 

![Screenshot 2023-04-19 at 08 36 21](https://user-images.githubusercontent.com/26961591/232968577-93248765-92fb-4b4f-90c2-ec7d5e9836a2.png)


