### PR TITLE
Fix: Table Sort reset after reload

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -244,7 +244,6 @@ class AllEvents extends React.Component {
               >
                 <Link
                   onClick={() => {
-                    console.log("clicked");
                     this.props.toggleLive({
                       show: true,
                       component: this.addToHomePageUI({ id }),
@@ -265,7 +264,6 @@ class AllEvents extends React.Component {
                     <StarsIcon
                       size="small"
                       variant="outlined"
-                      // color={"secondary"}
                       sx={{
                         color: "#bcbcbc",
                       }}
@@ -368,17 +366,18 @@ class AllEvents extends React.Component {
   }
 
   addEventToHomePage = (id) => {
-     const { allEvents, putEventsInRedux } = this.props;
+    const { allEvents, putEventsInRedux } = this.props;
     const data = allEvents || [];
     let event =data?.find((item) => item.id?.toString() === id?.toString()) || {};
     const index = data.findIndex((a) => a.id?.toString() === id);
-
 
     const toSend = {
       event_id: id,
       community_id: event?.community?.id,
     };
-    if (new Date(event?.start_date_and_time) < Date.now()) {
+
+    // BHN - use end_date_and_time so ongoing events/campaigns can show on home page
+    if (new Date(event?.end_date_and_time) < Date.now()) {
       this.props.toggleToast({
         open: true,
         message: "Event is out of date",
@@ -386,6 +385,7 @@ class AllEvents extends React.Component {
       });
       return;
     }
+  
     apiCall("home_page_settings.addEvent", toSend).then((res) => {
       if (res.success) {
         event.is_on_home_page = res?.data?.status

--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -49,6 +49,7 @@ import CallMadeIcon from "@mui/icons-material/CallMade";
 import { FROM } from "../../../utils/constants";
 import Loader from "../../../utils/components/Loader";
 import HomeIcon from "@mui/icons-material/Home";
+import StarsIcon from "@mui/icons-material/Stars";
 class AllEvents extends React.Component {
   constructor(props) {
     super(props);
@@ -176,9 +177,9 @@ class AllEvents extends React.Component {
                     closeAfterConfirmation: true,
                   })
                 }
-                label={d.isLive ? "Yes" : "No"}
+                label={d?.isLive ? "Yes" : "No"}
                 className={`${
-                  d.isLive ? classes.yesLabel : classes.noLabel
+                  d?.isLive ? classes.yesLabel : classes.noLabel
                 } touchable-opacity`}
               />
             );
@@ -238,7 +239,8 @@ class AllEvents extends React.Component {
               )}
               <Tooltip
                 title={`${is_on_home_page ? "Remove" : "Add"} event ${
-                  is_on_home_page ? "from" : "to" } community's homepage`}
+                  is_on_home_page ? "from" : "to"
+                } community's homepage`}
               >
                 <Link
                   onClick={() => {
@@ -252,7 +254,7 @@ class AllEvents extends React.Component {
                   }}
                 >
                   {is_on_home_page ? (
-                    <HomeIcon
+                    <StarsIcon
                       size="small"
                       variant="outlined"
                       sx={{
@@ -260,10 +262,13 @@ class AllEvents extends React.Component {
                       }}
                     />
                   ) : (
-                    <HomeIcon
+                    <StarsIcon
                       size="small"
                       variant="outlined"
-                      color={"secondary"}
+                      // color={"secondary"}
+                      sx={{
+                        color: "#bcbcbc",
+                      }}
                     />
                   )}
                 </Link>

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/table /METable.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/table /METable.js
@@ -23,6 +23,7 @@ function METable(props) {
   const filterObject = useRef({});
   const pageTableProperties = useRef({});
   const [tableColumns, setTableColumns] = useState([]);
+  const [sortOrder, setSortOrder] = useState();
 
   const {
     classes,
@@ -65,32 +66,33 @@ function METable(props) {
     return columns;
   };
 
-  const retrieveSortOptionsAndSort = (columns) => {
+  const retrieveSortOptionsAndSort = (obj=null) => {
+    let { columns } = tableProps || {};
     const properties = getProperties();
-    if (!properties.sortDirections) return columns;
-    const [columnIndex, sortDirection] = Object.entries(
-      properties.sortDirections
-    )[0];
-    let columnThatNeedsToBeSorted = columns.splice(columnIndex, 1)[0];
+    if (!properties.sortOrder) return ;
+    if (obj) {
+       setSortOrder(obj);
+       return
+    }
+    const [columnIndex, sortDirection] = Object.entries( properties.sortOrder)[0];
+    let columnThatNeedsToBeSorted = columns[columnIndex];
     if (!columnThatNeedsToBeSorted) return columns;
-
-    const theOptionsOnThatColumn = columnThatNeedsToBeSorted.options || {};
-    // update the target column with the retrieved colum sort direction
-    columnThatNeedsToBeSorted = {
-      ...columnThatNeedsToBeSorted,
-      options: { ...theOptionsOnThatColumn, ...sortDirection },
-    };
-    columns.splice(columnIndex, 0, columnThatNeedsToBeSorted); // put the column back in the list,and in the same position
-    return columns;
+    let order = {name:columnThatNeedsToBeSorted?.name,direction:sortDirection?.sortOrder}
+    setSortOrder(order);
   };
+
+
+  useEffect(()=>{
+    retrieveSortOptionsAndSort();
+  }, [])
 
   useEffect(() => {
     let { columns } = tableProps || {};
     var modified;
     const properties = getProperties();
     pageTableProperties.current = properties;
-    columns = retrieveSortOptionsAndSort(columns);
     modified = retrieveFiltersFromLastVisit(columns);
+    retrieveSortOptionsAndSort();
     setTableColumns(modified);
   }, [filtersFromRedux]);
 
@@ -201,18 +203,23 @@ function METable(props) {
 
   const whenAdminSortsAColumn = (columnName, direction) => {
     const columnIndex = tableColumns.findIndex((c) => c.name === columnName); // get the index of the column thats been sorted
-    const obj = pageTableProperties.current.sortDirections || {}; // look for an existing list of already sorted colums
+    const obj = pageTableProperties.current.sortOrder || {}; // look for an existing list of already sorted colums
     if (columnIndex === -1) return;
+    retrieveSortOptionsAndSort({
+      name: columnName,
+      direction
+    });
     const newObj = {
-      [columnIndex]: { sortDirection: DIRECTIONS[direction] }, // make new sorting object (cos the table can only be sorted one column at a time)
+      [columnIndex]: { sortOrder: direction}, // make new sorting object (cos the table can only be sorted one column at a time)
     };
-    pageTableProperties.current.sortDirections = newObj; // update the page properties object with the new set of sortDirections
+    pageTableProperties.current.sortOrder = newObj; // update the page properties object with the new set of sortDirections
     savePageProperties(pageTableProperties.current); // then save these new changes to localStorage
   };
 
   var { search, rowsPerPage } = getProperties();
   const options = {
     onFilterChange,
+    sortOrder,
     ...(tableProps.options || {}),
     onSearchChange,
     searchText: search || "",

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/table /METable.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/table /METable.js
@@ -83,7 +83,17 @@ function METable(props) {
 
 
   useEffect(()=>{
+    let { columns } = tableProps || {};
     retrieveSortOptionsAndSort();
+
+    // reset sort on third click
+    columns = columns?.map(column=>{
+      column.options.sortThirdClickReset = true
+      return column
+    })
+
+    setTableColumns(columns)
+
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
####  Summary / Highlights
Related [Issue](https://github.com/massenergize/frontend-admin/issues/937)
This pull request (Pr) addresses the problem with resetting the Material-UI (MUI) table's sorting state when the page reloads. The issue was causing inconvenience for users who had already sorted the table data and then had to redo the sorting every time they refreshed the page or changed the page. With this fix, the MUI table retains its sorting order even after reloading the page or switching pages, improving the user experience.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

https://user-images.githubusercontent.com/42780120/233950030-266b544f-b04d-4959-8278-6dfb8bbb6eb0.mp4


#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
