### PR TITLE
Clear grey buttons on table

### DIFF
--- a/app/config/config.json
+++ b/app/config/config.json
@@ -1,5 +1,5 @@
 {
-  "IS_LOCAL": false,
+  "IS_LOCAL": true,
   "IS_PROD": false,
   "IS_CANARY": false,
   "BUILD_VERSION": "4.9.20"

--- a/app/config/config.json
+++ b/app/config/config.json
@@ -1,5 +1,5 @@
 {
-  "IS_LOCAL": true,
+  "IS_LOCAL": false,
   "IS_PROD": false,
   "IS_CANARY": false,
   "BUILD_VERSION": "4.9.20"

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/paper block/MEPaperBlock.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/paper block/MEPaperBlock.js
@@ -7,7 +7,29 @@ function MEPaperBlock({
   title,
   subtitle,
   containerStyle,
+  banner,
+  icon,
 }) {
+  if (banner)
+    return (
+      <div
+        className="elevate-float"
+        style={{
+          width: "100%",
+          minHeight: "auto",
+          padding: "15px 25px",
+          marginBottom: 10,
+          background: "#fefbf3",
+          borderRadius: 10,
+          display: "flex",
+          alignItems: "center",
+          ...(containerStyle || {}),
+        }}
+      >
+        {icon && <i className={icon} style={{ marginRight: 7 }} />}
+        {children}
+      </div>
+    );
   return (
     <div>
       <div

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/paper block/MEPaperBlock.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/paper block/MEPaperBlock.js
@@ -23,7 +23,7 @@ function MEPaperBlock({
         }}
       >
         {!customHeader ? (
-          <div style={{ marginBottom: 20 }}>
+          <div style={{ marginBottom: title ? 20 : 0 }}>
             {title && (
               <Typography
                 variant="h3"

--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/table /utils.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/table /utils.js
@@ -1,0 +1,28 @@
+import { TableFilterList } from "mui-datatables";
+import React from "react";
+import Chip from "@mui/material/Chip";
+const OurChip = ({ label, onDelete }) => {
+  return (
+    <Chip
+      variant="contained"
+      // color="secondary"
+      label={label}
+      onDelete={onDelete}
+    />
+  );
+};
+const EmptyChip = () => <></>;
+
+export const renderInvisibleChips = (invisible) => {
+  const CustomFilterList = (props) => {
+    return (
+      <>
+        <TableFilterList
+          {...props}
+          ItemComponent={invisible ? EmptyChip : OurChip}
+        />
+      </>
+    );
+  };
+  return CustomFilterList;
+};

--- a/app/containers/MassEnergizeSuperAdmin/Messages/CommunityAdminMessages.js
+++ b/app/containers/MassEnergizeSuperAdmin/Messages/CommunityAdminMessages.js
@@ -37,6 +37,7 @@ import {
 import ApplyFilterButton from "../../../utils/components/applyFilterButton/ApplyFilterButton";
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import Loader from "../../../utils/components/Loader";
+import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 
 export const replyToMessage = ({ pathname, props, transfer }) => {
   // const pathname = `/admin/edit/${id}/message`;
@@ -98,7 +99,19 @@ class AllCommunityAdminMessages extends React.Component {
   componentWillUnmount() {
     // Clears location state when this component is unmounting
     window.history.replaceState({}, document.title);
+    const { comingFromDashboard } = this.state;
+    if (comingFromDashboard) this.removeFilters();
   }
+
+  removeFilters() {
+    const { tableFilters, updateTableFilters } = this.props;
+    const key = PAGE_PROPERTIES.ALL_ADMIN_MESSAGES.key + FILTERS;
+    updateTableFilters({
+      ...(tableFilters || {}),
+      [key]: {},
+    });
+  }
+
   componentDidMount() {
     const { state } = this.props.location;
     const {
@@ -111,14 +124,14 @@ class AllCommunityAdminMessages extends React.Component {
     const ids = state && state.ids;
     const comingFromDashboard = ids?.length;
     if (comingFromDashboard) {
-      this.setState({ saveFilters: false });
+      this.setState({ saveFilters: false, comingFromDashboard });
       const key = PAGE_PROPERTIES.ALL_ADMIN_MESSAGES.key + FILTERS;
       updateTableFilters({
         ...(tableFilters || {}),
         [key]: { 0: { list: ids } },
       });
-    }
-    
+    } else this.setState({ ignoreSavedFilters: true });
+
     apiCall("/messages.listForCommunityAdmin", {
       limit: getLimit(PAGE_PROPERTIES.ALL_ADMIN_MESSAGES.key),
     }).then((allMessagesResponse) => {
@@ -295,7 +308,7 @@ class AllCommunityAdminMessages extends React.Component {
   render() {
     const title = brand.name + " - Community Admin Messages";
     const description = brand.desc;
-    const { columns } = this.state;
+    const { columns, comingFromDashboard } = this.state;
     const {
       classes,
       messages,
@@ -399,6 +412,22 @@ class AllCommunityAdminMessages extends React.Component {
           <meta property="twitter:title" content={title} />
           <meta property="twitter:description" content={description} />
         </Helmet>
+        {comingFromDashboard && (
+          <MEPaperBlock
+            containerStyle={{
+              minHeight: "auto",
+              padding: "15px 25px",
+              marginBottom: 10,
+              background: "#fefbf3",
+            }}
+          >
+            <Typography>
+              <i className="fa fa-bullhorn" /> The messages you have not
+              answered yet are currently preselected and sorted in the table
+              for you. Feel free to clear all selections with the filter panel.
+            </Typography>
+          </MEPaperBlock>
+        )}
         <METable
           classes={classes}
           page={PAGE_PROPERTIES.ALL_ADMIN_MESSAGES}

--- a/app/containers/MassEnergizeSuperAdmin/Messages/CommunityAdminMessages.js
+++ b/app/containers/MassEnergizeSuperAdmin/Messages/CommunityAdminMessages.js
@@ -38,6 +38,7 @@ import ApplyFilterButton from "../../../utils/components/applyFilterButton/Apply
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import Loader from "../../../utils/components/Loader";
 import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
+import { renderInvisibleChips } from "../ME  Tools/table /utils";
 
 export const replyToMessage = ({ pathname, props, transfer }) => {
   // const pathname = `/admin/edit/${id}/message`;
@@ -99,18 +100,18 @@ class AllCommunityAdminMessages extends React.Component {
   componentWillUnmount() {
     // Clears location state when this component is unmounting
     window.history.replaceState({}, document.title);
-    const { comingFromDashboard } = this.state;
-    if (comingFromDashboard) this.removeFilters();
+    // const { comingFromDashboard } = this.state;
+    // if (comingFromDashboard) this.removeFilters();
   }
 
-  removeFilters() {
-    const { tableFilters, updateTableFilters } = this.props;
-    const key = PAGE_PROPERTIES.ALL_ADMIN_MESSAGES.key + FILTERS;
-    updateTableFilters({
-      ...(tableFilters || {}),
-      [key]: {},
-    });
-  }
+  // removeFilters() {
+  //   const { tableFilters, updateTableFilters } = this.props;
+  //   const key = PAGE_PROPERTIES.ALL_ADMIN_MESSAGES.key + FILTERS;
+  //   updateTableFilters({
+  //     ...(tableFilters || {}),
+  //     [key]: {},
+  //   });
+  // }
 
   componentDidMount() {
     const { state } = this.props.location;
@@ -124,13 +125,13 @@ class AllCommunityAdminMessages extends React.Component {
     const ids = state && state.ids;
     const comingFromDashboard = ids?.length;
     if (comingFromDashboard) {
-      this.setState({ saveFilters: false, comingFromDashboard });
-      const key = PAGE_PROPERTIES.ALL_ADMIN_MESSAGES.key + FILTERS;
-      updateTableFilters({
-        ...(tableFilters || {}),
-        [key]: { 0: { list: ids } },
-      });
-    } else this.setState({ ignoreSavedFilters: true });
+      this.setState({ saveFilters: false, comingFromDashboard, ids });
+      // const key = PAGE_PROPERTIES.ALL_ADMIN_MESSAGES.key + FILTERS;
+      // updateTableFilters({
+      //   ...(tableFilters || {}),
+      //   [key]: { 0: { list: ids } },
+      // });
+    } else this.setState({ comingFromDashboard: false });
 
     apiCall("/messages.listForCommunityAdmin", {
       limit: getLimit(PAGE_PROPERTIES.ALL_ADMIN_MESSAGES.key),
@@ -305,6 +306,14 @@ class AllCommunityAdminMessages extends React.Component {
     );
   }
 
+  getData(source) {
+    if (!source) return [];
+    const { ids, comingFromDashboard } = this.state;
+    if (!comingFromDashboard || !ids) return source;
+    const items = source.filter((item) => ids.includes(item.id));
+    // console.log("lets see items", items);
+    return items;
+  }
   render() {
     const title = brand.name + " - Community Admin Messages";
     const description = brand.desc;
@@ -316,7 +325,9 @@ class AllCommunityAdminMessages extends React.Component {
       meta,
       putMetaDataToRedux,
     } = this.props;
-    const data = this.fashionData(messages); // not ready for this yet: && this.props.messages.filter(item=>item.parent===null));
+    const content = this.getData(messages);
+    // console.log("THIS IS THE CONTENT", content)
+    const data = this.fashionData(content); // not ready for this yet: && this.props.messages.filter(item=>item.parent===null));
     const metaData = meta && meta.adminMessages;
     const options = {
       filterType: "dropdown",
@@ -413,18 +424,20 @@ class AllCommunityAdminMessages extends React.Component {
           <meta property="twitter:description" content={description} />
         </Helmet>
         {comingFromDashboard && (
-          <MEPaperBlock
-            containerStyle={{
-              minHeight: "auto",
-              padding: "15px 25px",
-              marginBottom: 10,
-              background: "#fefbf3",
-            }}
-          >
+          <MEPaperBlock icon="fa fa-bullhorn" banner>
             <Typography>
-              <i className="fa fa-bullhorn" /> The messages you have not
-              answered yet are currently preselected and sorted in the table
-              for you. Feel free to clear all selections with the filter panel.
+              The messages you have not answered yet are currently preselected
+              and sorted in the table for you. Feel free to
+              <Link
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  this.setState({ comingFromDashboard: false });
+                }}
+              >
+                {" "}
+                clear all selections.
+              </Link>
             </Typography>
           </MEPaperBlock>
         )}
@@ -436,14 +449,18 @@ class AllCommunityAdminMessages extends React.Component {
             data: data,
             columns: columns,
             options: options,
+            // components: {
+            //   TableFilterList: renderInvisibleChips(comingFromDashboard),
+            // },
           }}
-          customFilterObject={{
-            0: {
-              list: this.state.ids,
-            },
-          }} // "0" here is the index of the "ID" column in the table
-          ignoreSavedFilters={this.state.ignoreSavedFilters}
-          saveFilters={this.state.saveFilters}
+          // customFilterObject={{
+          //   0: {
+          //     list: this.state.ids,
+          //   },
+          // }} // "0" here is the index of the "ID" column in the table
+          // ignoreSavedFilters={this.state.ignoreSavedFilters}
+          ignoreSavedFilters={comingFromDashboard}
+          saveFilters={!comingFromDashboard}
         />
       </div>
     );

--- a/app/containers/MassEnergizeSuperAdmin/Messages/TeamAdminMessages.js
+++ b/app/containers/MassEnergizeSuperAdmin/Messages/TeamAdminMessages.js
@@ -35,8 +35,9 @@ import {
 } from "../../../utils/helpers";
 import ApplyFilterButton from "../../../utils/components/applyFilterButton/ApplyFilterButton";
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
-import { replyToMessage } from "./CommunityAdminMessages";
+import { getData, replyToMessage } from "./CommunityAdminMessages";
 import Loader from "../../../utils/components/Loader";
+import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 class AllTeamAdminMessages extends React.Component {
   constructor(props) {
     super(props);
@@ -64,13 +65,15 @@ class AllTeamAdminMessages extends React.Component {
     const comingFromDashboard = ids && ids.length;
 
     const key = PAGE_PROPERTIES.ALL_TEAM_MESSAGES.key + FILTERS;
-    if (comingFromDashboard) {
-      this.setState({ saveFilters: false });
-      updateTableFilters({
-        ...(tableFilters || {}),
-        [key]: { 0: { list: ids } },
-      });
-    }
+    if (comingFromDashboard) this.setState({ comingFromDashboard, ids });
+    else this.setState({ comingFromDashboard: false });
+    // if (comingFromDashboard) {
+    //   this.setState({ saveFilters: false });
+    //   updateTableFilters({
+    //     ...(tableFilters || {}),
+    //     [key]: { 0: { list: ids } },
+    //   });
+    // }
 
     apiCall("/messages.listTeamAdminMessages", {
       limit: getLimit(PAGE_PROPERTIES.ALL_TEAM_MESSAGES.key),
@@ -258,7 +261,7 @@ class AllTeamAdminMessages extends React.Component {
   render() {
     const title = brand.name + " - Team Admin Messages";
     const description = brand.desc;
-    const { columns } = this.state;
+    const { columns, comingFromDashboard, ids } = this.state;
     const {
       classes,
       teamMessages,
@@ -266,7 +269,13 @@ class AllTeamAdminMessages extends React.Component {
       meta,
       putMetaDataToRedux,
     } = this.props;
-    const data = this.fashionData((teamMessages && teamMessages) || []);
+
+    const content = getData({
+      source: (teamMessages && teamMessages) || [],
+      comingFromDashboard,
+      ids,
+    });
+    const data = this.fashionData(content);
 
     const metaData = meta && meta.teamMessages;
     const options = {
@@ -364,6 +373,25 @@ class AllTeamAdminMessages extends React.Component {
           <meta property="twitter:title" content={title} />
           <meta property="twitter:description" content={description} />
         </Helmet>
+        {comingFromDashboard && (
+          <MEPaperBlock icon="fa fa-bullhorn" banner>
+            <Typography>
+              The <b>{comingFromDashboard}</b> team message(s) you have not
+              answered yet are currently pre-selected and sorted in the table for
+              you. Feel free to
+              <Link
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  this.setState({ comingFromDashboard: false });
+                }}
+              >
+                {" "}
+                clear all selections.
+              </Link>
+            </Typography>
+          </MEPaperBlock>
+        )}
         <METable
           classes={classes}
           page={PAGE_PROPERTIES.ALL_TEAM_MESSAGES}
@@ -373,7 +401,8 @@ class AllTeamAdminMessages extends React.Component {
             columns: columns,
             options: options,
           }}
-          saveFilters={this.state.saveFilters}
+          ignoreSavedFilters={comingFromDashboard}
+          saveFilters={!comingFromDashboard}
         />
       </div>
     );

--- a/app/containers/MassEnergizeSuperAdmin/Summary/ContinueWhereYouLeft.js
+++ b/app/containers/MassEnergizeSuperAdmin/Summary/ContinueWhereYouLeft.js
@@ -45,10 +45,11 @@ function ContinueWhereYouLeft() {
       style={{
         display: "flex",
         alignItems: "center",
-        background: "rgb(253 235 222)",
+        background: "#fefbf3",
         color: "black",
         padding: "15px 20px",
         marginBottom: 20,
+        borderRadius: 10,
       }}
     >
       <Typography

--- a/app/containers/MassEnergizeSuperAdmin/Teams/AllTeams.js
+++ b/app/containers/MassEnergizeSuperAdmin/Teams/AllTeams.js
@@ -47,6 +47,8 @@ import {
 import ApplyFilterButton from "../../../utils/components/applyFilterButton/ApplyFilterButton";
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import Loader from "../../../utils/components/Loader";
+import { getData } from "../Messages/CommunityAdminMessages";
+import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 
 class AllTeams extends React.Component {
   constructor(props) {
@@ -71,14 +73,14 @@ class AllTeams extends React.Component {
     const comingFromDashboard = ids && ids.length;
 
     if (!comingFromDashboard) return fetchTeams();
-    this.setState({ saveFilters: false });
+    this.setState({ saveFilters: false, comingFromDashboard, ids });
 
-    const key = PAGE_PROPERTIES.ALL_TEAMS.key + FILTERS;
+    // const key = PAGE_PROPERTIES.ALL_TEAMS.key + FILTERS;
 
-    updateTableFilters({
-      ...(tableFilters || {}),
-      [key]: { 0: { list: ids } },
-    });
+    // updateTableFilters({
+    //   ...(tableFilters || {}),
+    //   [key]: { 0: { list: ids } },
+    // });
 
     var content = {
       fieldKey: "team_ids",
@@ -368,7 +370,7 @@ class AllTeams extends React.Component {
   render() {
     const title = brand.name + " - All Teams";
     const description = brand.desc;
-    const { columns } = this.state;
+    const { columns, comingFromDashboard, ids } = this.state;
     const {
       classes,
       allTeams,
@@ -377,7 +379,9 @@ class AllTeams extends React.Component {
       meta,
       putMetaDataToRedux,
     } = this.props;
-    const data = this.fashionData(allTeams);
+
+    const content = getData({ source: allTeams, comingFromDashboard, ids });
+    const data = this.fashionData(content);
     const metaData = meta && meta.teams;
     const options = {
       filterType: "dropdown",
@@ -474,7 +478,26 @@ class AllTeams extends React.Component {
           <meta property="twitter:title" content={title} />
           <meta property="twitter:description" content={description} />
         </Helmet>
-        {/* {this.showCommunitySwitch()} */}
+
+        {comingFromDashboard && (
+          <MEPaperBlock icon="fa fa-bullhorn" banner>
+            <Typography>
+              The <b>{comingFromDashboard}</b> team(s) you have not approved yet
+              are currently pre-selected and sorted in the table for you. Feel
+              free to
+              <Link
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  this.setState({ comingFromDashboard: false });
+                }}
+              >
+                {" "}
+                clear all selections.
+              </Link>
+            </Typography>
+          </MEPaperBlock>
+        )}
         <METable
           classes={classes}
           page={PAGE_PROPERTIES.ALL_TEAMS}
@@ -484,7 +507,8 @@ class AllTeams extends React.Component {
             columns: columns,
             options: options,
           }}
-          saveFilters={this.state.saveFilters}
+          ignoreSavedFilters={comingFromDashboard}
+          saveFilters={!comingFromDashboard}
         />
       </div>
     );

--- a/app/containers/MassEnergizeSuperAdmin/Testimonials/AllTestimonials.js
+++ b/app/containers/MassEnergizeSuperAdmin/Testimonials/AllTestimonials.js
@@ -43,6 +43,8 @@ import {
 import ApplyFilterButton from "../../../utils/components/applyFilterButton/ApplyFilterButton";
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import Loader from "../../../utils/components/Loader";
+import { getData } from "../Messages/CommunityAdminMessages";
+import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 
 class AllTestimonials extends React.Component {
   constructor(props) {
@@ -80,13 +82,13 @@ class AllTestimonials extends React.Component {
       },
     };
 
-    this.setState({ saveFilters: false });
-    const key = PAGE_PROPERTIES.ALL_TESTIMONIALS.key + FILTERS;
+    this.setState({ comingFromDashboard, ids });
+    // const key = PAGE_PROPERTIES.ALL_TESTIMONIALS.key + FILTERS;
 
-    updateTableFilters({
-      ...(tableFilters || {}),
-      [key]: { 0: { list: ids } },
-    });
+    // updateTableFilters({
+    //   ...(tableFilters || {}),
+    //   [key]: { 0: { list: ids } },
+    // });
 
     fetchTestimonials((data, failed) => {
       if (failed)
@@ -398,7 +400,7 @@ class AllTestimonials extends React.Component {
   render() {
     const title = brand.name + " - All Testimonials";
     const description = brand.desc;
-    const { columns, loading } = this.state;
+    const { columns, loading, comingFromDashboard, ids } = this.state;
     const {
       classes,
       allTestimonials,
@@ -407,8 +409,9 @@ class AllTestimonials extends React.Component {
       meta,
       putMetaDataToRedux,
     } = this.props;
-
-    const data = this.fashionData(allTestimonials || []);
+    
+    const content = getData({ source: allTestimonials || [], comingFromDashboard, ids });
+    const data = this.fashionData(content);
     const metaData = meta && meta.testimonials;
     const options = {
       filterType: "dropdown",
@@ -522,6 +525,25 @@ class AllTestimonials extends React.Component {
           <meta property="twitter:title" content={title} />
           <meta property="twitter:description" content={description} />
         </Helmet>
+        {comingFromDashboard && (
+          <MEPaperBlock icon="fa fa-bullhorn" banner>
+            <Typography>
+              The <b>{comingFromDashboard}</b> testimonial(s) you have not approved yet
+              are currently pre-selected and sorted in the table for you. Feel
+              free to
+              <Link
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  this.setState({ comingFromDashboard: false });
+                }}
+              >
+                {" "}
+                clear all selections.
+              </Link>
+            </Typography>
+          </MEPaperBlock>
+        )}
         <METable
           classes={classes}
           page={PAGE_PROPERTIES.ALL_TESTIMONIALS}
@@ -531,7 +553,8 @@ class AllTestimonials extends React.Component {
             columns: columns,
             options: options,
           }}
-          saveFilters={this.state.saveFilters}
+          ignoreSavedFilters={comingFromDashboard}
+          saveFilters={!comingFromDashboard}
         />
       </div>
     );

--- a/app/containers/MassEnergizeSuperAdmin/Users/AllUsers.js
+++ b/app/containers/MassEnergizeSuperAdmin/Users/AllUsers.js
@@ -41,6 +41,8 @@ import {
   KeyboardArrowRight,
 } from "@mui/icons-material";
 import RenderVisitLogs from "./RenderVisitLogs";
+import { getData } from "../Messages/CommunityAdminMessages";
+import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 
 class AllUsers extends React.Component {
   constructor(props) {
@@ -71,13 +73,13 @@ class AllUsers extends React.Component {
 
     if (!comingFromDashboard) return fetchUsers();
 
-    this.setState({ updating: true, saveFilters: false });
-    const key = PAGE_PROPERTIES.ALL_USERS.key + FILTERS;
+    this.setState({ updating: true, comingFromDashboard, ids });
+    // const key = PAGE_PROPERTIES.ALL_USERS.key + FILTERS;
 
-    updateTableFilters({
-      ...(tableFilters || {}),
-      [key]: { 3: { list: ids } },
-    });
+    // updateTableFilters({
+    //   ...(tableFilters || {}),
+    //   [key]: { 3: { list: ids } },
+    // });
 
     var content = {
       fieldKey: "user_emails",
@@ -169,7 +171,7 @@ class AllUsers extends React.Component {
         filter: false,
         download: false,
         customBodyRender: (d) => {
-          const { id, user_portal_visits } =d ||{}
+          const { id, user_portal_visits } = d || {};
           const isOneRecord = user_portal_visits?.length === 1;
           const isEmpty = !user_portal_visits?.length;
 
@@ -256,7 +258,7 @@ class AllUsers extends React.Component {
   render() {
     const title = brand.name + " - Users";
     const description = brand.desc;
-    const { columns } = this.state;
+    const { columns, comingFromDashboard, ids, updating } = this.state;
     const {
       classes,
       allUsers,
@@ -265,7 +267,14 @@ class AllUsers extends React.Component {
       meta,
       putMetaDataToRedux,
     } = this.props;
-    const data = this.fashionData(allUsers || []);
+
+    const content = getData({
+      source: allUsers || [],
+      comingFromDashboard,
+      ids,
+      valueExtractor: (item) => item.email,
+    });
+    const data = this.fashionData(content);
     const metaData = meta && meta.users;
 
     const options = {
@@ -364,10 +373,28 @@ class AllUsers extends React.Component {
           <meta property="twitter:description" content={description} />
         </Helmet>
 
-        {this.state.updating && (
+        {updating && (
           <LinearBuffer asCard message="Checking for updates..." lines={1} />
         )}
 
+        {comingFromDashboard && !updating && (
+          <MEPaperBlock icon="fa fa-bullhorn" banner>
+            <Typography>
+              The users involved in the interactions are currently pre-selected
+              and sorted in the table for you. Feel free to
+              <Link
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  this.setState({ comingFromDashboard: false });
+                }}
+              >
+                {" "}
+                clear all selections.
+              </Link>
+            </Typography>
+          </MEPaperBlock>
+        )}
         <METable
           classes={classes}
           page={PAGE_PROPERTIES.ALL_USERS}
@@ -377,7 +404,8 @@ class AllUsers extends React.Component {
             columns: columns,
             options: options,
           }}
-          saveFilters={this.state.saveFilters}
+          ignoreSavedFilters={comingFromDashboard}
+          saveFilters={!comingFromDashboard}
         />
       </div>
     );


### PR DESCRIPTION
### Related Ticket : https://github.com/massenergize/frontend-admin/issues/966

## Context 
So, the summary of what's happened here is that, when admins click through the link on the "What next" card into the pages where items are shown in the table, we no longer tell the table to preselect items(Cos the table is wired to show chips when you preselect). That said, I also didnt completely disable the chip options as Kaat prescribed in the ticket. Because in all other cases, I think showing the chips is useful for communicating to admins what filters are active on the table. 

So in this PR, I have changed the logic for preselection when an admin comes from the dashboard. For instance, when an admin clicks on "4 unanswered messages" and is sent to the the messages table, I manually sieve through the content and only show them the "4" unanswered messages. Then I show a note that tells them that the content in the table isn't everything, and that there are active filters. I also provide an option for them to clear all  the preselections and go back to the normal list of items that are supposed to show in the table.

![Screenshot 2023-05-22 at 09 32 56](https://github.com/massenergize/frontend-admin/assets/26961591/4b710056-eaf3-479e-8778-7945f6d40c6b)


## DEMO 

https://github.com/massenergize/frontend-admin/assets/26961591/09696bcc-4728-484e-bffa-0d840a9d8da9


