### PR TITLE
No Dupes In Filtered Data

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/Users/AllUsers.js
+++ b/app/containers/MassEnergizeSuperAdmin/Users/AllUsers.js
@@ -84,7 +84,7 @@ class AllUsers extends React.Component {
       apiURL: "/users.listForCommunityAdmin",
       props: this.props,
       dataSource: [],
-      valueExtractor: (user) => user.email,
+      separationOptions:{valueExtractor: (user) => user.email,},
       reduxFxn: putUsersInRedux,
       args: {
         limit: getLimit(PAGE_PROPERTIES.ALL_USERS.key),


### PR DESCRIPTION
### Related Ticket: https://github.com/massenergize/frontend-admin/issues/963 

## Summary 

- [X] So basically when filtering, we kind of check for which items are available locally, then fetch items that are not there from the backend. On the user listing page, we didnt specify the valueExtractor function as the right param in the separator function. Which essentially meant our function would always bring out the entire list of items we are looking for as "Not found". So it would then go to the backend and fetch all of them and then come and append again 💀 . Thats fixed now. 

## Testing
@BradHN1  if you do the tests you did again, you should not see any duplicates now. 

## Others 
I also saw that you mentioned something about this part of the table in the ticket @BradHN1. 
![Screenshot 2023-05-22 at 11 01 05](https://github.com/massenergize/frontend-admin/assets/26961591/d90f2457-6512-44a4-b681-40e465c0c961)

Yes,I dont think the values at the bottom there are a reflection of the contents in the table at any point in time. I think @abdullai-t 's pagination makes it use the overall count value of  whatever dataset we are looking at from the backend.... @abdullai-t ...? Is that it? Can you take charge of that?
