### PR TITLE
Form Warning for Empty Required Fields

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/Actions/CreateNewActionForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Actions/CreateNewActionForm.js
@@ -203,7 +203,7 @@ const createFormJson = ({
                 name: "is_global",
                 label: "Is this Action a Template?",
                 fieldType: "Radio",
-                isRequired: false,
+                isRequired: true,
                 // defaultValue: progress.is_global || "false",
                 dbName: "is_global",
                 readOnly: false,

--- a/app/containers/MassEnergizeSuperAdmin/Actions/EditActionForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Actions/EditActionForm.js
@@ -303,7 +303,7 @@ const createFormJson = ({
                 name: "is_global",
                 label: "Is this Action a Template?",
                 fieldType: "Radio",
-                isRequired: false,
+                isRequired: true,
                 defaultValue: action.is_global ? "true" : "false",
                 dbName: "is_global",
                 readOnly: false,

--- a/app/containers/MassEnergizeSuperAdmin/Actions/EditActionForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Actions/EditActionForm.js
@@ -311,22 +311,22 @@ const createFormJson = ({
                   { id: "false", value: "No" },
                   { id: "true", value: "Yes" },
                 ],
-                child: {
-                  valueToCheck: "false",
-                  fields: [
-                    {
-                      name: "community",
-                      label: "Primary Community (Select one)",
-                      placeholder: "",
-                      fieldType: "Dropdown",
-                      defaultValue:
-                        action.community && "" + action.community.id,
-                      dbName: "community_id",
-                      data: [{ displayName: "--", id: "" }, ...communities],
-                      isRequired: true,
-                    },
-                  ],
-                },
+                conditionalDisplays: [
+                  {
+                    valueToCheck: "false",
+                    fields: [
+                      {
+                        name: "community",
+                        label: "Primary Community (select one)",
+                        fieldType: "Dropdown",
+                        // defaultValue: progress.community || null,
+                        dbName: "community_id",
+                        data: [{ displayName: "--", id: "" }, ...communities],
+                        isRequired: true,
+                      },
+                    ],
+                  },
+                ],
               }
             : {
                 name: "community",

--- a/app/containers/MassEnergizeSuperAdmin/Events/CreateNewEventForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/CreateNewEventForm.js
@@ -257,7 +257,7 @@ const createFormJson = ({
               { id: "true", value: "Yes" },
             ],
             child: {
-              dbName: "recurring_details",
+              // dbName: "recurring_details",
               valueToCheck: "true",
               fields: [
                 {

--- a/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
@@ -409,6 +409,8 @@ const createFormJson = ({
 
   const is_super_admin = auth && auth.is_super_admin;
 
+  console.log("=== event ===", event)
+
   //communities = is_super_admin
   //  ? communities
   //  : getAllowedCommunities({
@@ -510,7 +512,7 @@ const createFormJson = ({
               { id: "true", value: "Yes" },
             ],
             child: {
-              dbName: "recurring_details",
+              // dbName: "recurring_details",
               valueToCheck: "true",
               fields: [
                 {

--- a/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EditEventForm.js
@@ -409,8 +409,6 @@ const createFormJson = ({
 
   const is_super_admin = auth && auth.is_super_admin;
 
-  console.log("=== event ===", event)
-
   //communities = is_super_admin
   //  ? communities
   //  : getAllowedCommunities({

--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
@@ -378,8 +378,13 @@ class MassEnergizeForm extends Component {
         culprits = { ...culprits, ...result[1] };
       }
       else if(field.child) {
-        const result = this.requiredValuesAreProvided(formData, field?.child?.fields);
-        culprits = { ...culprits, ...result[1] };
+        let value = this.getValue(field.name);
+        if(value === field?.child?.valueToCheck){
+          const result = this.requiredValuesAreProvided(formData, field?.child.fields);
+          culprits = { ...culprits, ...result[1] };
+
+        }
+
       }
       else {
         const value = formData[field.name]; //field.name is what is used to set value, b4 cleaned up onSubmit
@@ -518,7 +523,6 @@ class MassEnergizeForm extends Component {
       formJson.fields
     );
     if (No) return this.setState({ requiredFields: culprits });
-
 
     // lets set the startCircularSpinner Value so the spinner starts spinning
     await this.setStateAsync({ startCircularSpinner: true });

--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
@@ -87,6 +87,7 @@ class MassEnergizeForm extends Component {
       error: null,
       formJson: null,
       readOnly: false,
+      requiredFields:{},
       // activeModal: null,
       // activeModalTitle: null,
       refreshKey: "default-form-state", // Change this value to any different string force a re-render in the form.
@@ -375,7 +376,12 @@ class MassEnergizeForm extends Component {
       if (field.children) {
         const result = this.requiredValuesAreProvided(formData, field.children);
         culprits = { ...culprits, ...result[1] };
-      } else {
+      }
+      else if(field.child) {
+        const result = this.requiredValuesAreProvided(formData, field?.child?.fields);
+        culprits = { ...culprits, ...result[1] };
+      }
+      else {
         const value = formData[field.name]; //field.name is what is used to set value, b4 cleaned up onSubmit
         // if field is readOnly - ignore the isRequired if present
         if (field.isRequired && !field.readOnly) {
@@ -513,6 +519,7 @@ class MassEnergizeForm extends Component {
     );
     if (No) return this.setState({ requiredFields: culprits });
 
+
     // lets set the startCircularSpinner Value so the spinner starts spinning
     await this.setStateAsync({ startCircularSpinner: true });
     // let's clean up the data
@@ -645,9 +652,11 @@ class MassEnergizeForm extends Component {
           return (
             <div key={field.name}>
               <div className={classes.field}>
-                <FormControl component="fieldset">
+                <FormControl component="fieldset" required={field.isRequired}>
                   {this.renderGeneralContent(field)}
-                  <FormLabel component="legend">{field.label}</FormLabel>
+                  <FormLabel component="legend">
+                    {field.label}
+                  </FormLabel>
 
                   <Select
                     multiple
@@ -655,6 +664,7 @@ class MassEnergizeForm extends Component {
                     name={field.name}
                     value={this.getValue(field.name) || []}
                     input={<Input id="select-multiple-chip" />}
+                    required={field.isRequired}
                     renderValue={(selected) => {
                       return (
                         <div
@@ -726,6 +736,7 @@ class MassEnergizeForm extends Component {
                     name={field.name}
                     onChange={this.handleCheckboxToggle}
                     disabled={field.readOnly}
+                    required={field.isRequired}
                   />
                 }
               />
@@ -735,7 +746,7 @@ class MassEnergizeForm extends Component {
       case FieldTypes.Dropdown:
         return (
           <div key={field.name}>
-            <FormControl className={classes.field}>
+            <FormControl className={classes.field} required={field.isRequired}>
               {this.renderGeneralContent(field)}
               <InputLabel
                 htmlFor={field.label}
@@ -748,11 +759,15 @@ class MassEnergizeForm extends Component {
                 label={field.label}
                 name={field.name}
                 onChange={async (newValue) => {
-                  await this.updateForm(field.name, newValue.target.value);
+                  await this.updateForm(
+                    field.name,
+                    newValue.target.value
+                  );
                 }}
                 inputProps={{
                   id: "age-native-simple",
                 }}
+                required={field.isRequired}
               >
                 <option value={this.getValue(field.name)}>
                   {this.getDisplayName(
@@ -769,7 +784,8 @@ class MassEnergizeForm extends Component {
                   ))}
               </Select>
               {field.child &&
-                this.getValue(field.name) === field.child.valueToCheck &&
+                this.getValue(field.name) ===
+                  field.child.valueToCheck &&
                 this.renderFields(field.child.fields)}
             </FormControl>
           </div>
@@ -1029,6 +1045,7 @@ class MassEnergizeForm extends Component {
               value={value}
               onChange={this.handleFormDataChange}
               disabled={field.readOnly || this.state.readOnly}
+              
             >
               {field.data.map((d) => (
                 <FormControlLabel
@@ -1187,6 +1204,7 @@ class MassEnergizeForm extends Component {
       successMsg,
       startCircularSpinner,
       readOnly,
+      requiredFields,
     } = this.state;
     if (!formJson) return <Loading />;
     return (
@@ -1287,6 +1305,7 @@ class MassEnergizeForm extends Component {
                     <CircularProgress className={classes.progress} />
                   </div>
                 )}
+
                 <div>
                   {/* {formJson && formJson.cancelLink && (
                     <Link to={formJson.cancelLink}>Cancel</Link>
@@ -1308,6 +1327,7 @@ class MassEnergizeForm extends Component {
                       Cancel
                     </Button>
                   )}
+
                   <Button
                     variant="contained"
                     color="secondary"
@@ -1317,6 +1337,16 @@ class MassEnergizeForm extends Component {
                     Submit
                   </Button>
                 </div>
+                {Object.keys(requiredFields).length > 0 && (
+                  <div
+                    style={{ display: "flex", justifyContent: "flex-end" }}
+                  >
+                    <Alert severity="warning">
+                      Oops! Looks like you missed something. Please complete
+                      all required fields
+                    </Alert>
+                  </div>
+                )}
               </form>
             </Paper>
           </Grid>

--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
@@ -1339,11 +1339,16 @@ class MassEnergizeForm extends Component {
                 </div>
                 {Object.keys(requiredFields).length > 0 && (
                   <div
-                    style={{ display: "flex", justifyContent: "flex-end" }}
+                    style={{ display: "flex", justifyContent: "center", marginTop:10 }}
                   >
                     <Alert severity="warning">
-                      Oops! Looks like you missed something. Please complete
-                      all required fields
+                      Oops! Looks like you missed these required fields{" "}
+                      {Object.keys(requiredFields).map((key, index) => (
+                        <span style={{ color: "tomato" }} key={key}>
+                          {key} {index !== Object.keys(requiredFields).length - 1 && ", "}
+                        </span>
+                      ))}
+                      . Please fill them out.
                     </Alert>
                   </div>
                 )}


### PR DESCRIPTION
####  Summary / Highlights
The FormGenerator performs field input validation to ensure that all required fields on the form are populated. However, the current validation process does not include conditional fields, which results in required conditional form fields not being validated. This pull request (PR) addresses this issue by implementing validation for conditional form fields. Additionally, an alert has been added near the submit button to notify users when they attempt to submit a form with unpopulated required fields.

#### Demo

https://github.com/massenergize/frontend-admin/assets/42780120/15c7df8f-818f-4d3d-9afd-e0fcc0a5c82a

#### Tickets Addressed

- [#993](https://github.com/massenergize/frontend-admin/issues/993)
- [#990 ](https://github.com/massenergize/frontend-admin/issues/990)

