### PR TITLE
Styles overwriting Richtext Styles Removed

### DIFF
--- a/app/styles/layout/_lists.scss
+++ b/app/styles/layout/_lists.scss
@@ -1,9 +1,9 @@
-ul,
-ol {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
+// ul,
+// ol {
+//   list-style-type: none;
+//   margin: 0;
+//   padding: 0;
+// }
 
 dl {
   margin: 0;


### PR DESCRIPTION
####  Related [issue](https://github.com/massenergize/frontend-admin/issues/1007)
 Just removed the CSS styles that are overwriting the styles in the rich-text editor.

#### New look
<img width="1516" alt="Screenshot 2023-06-15 at 11 11 46 AM" src="https://github.com/massenergize/frontend-admin/assets/42780120/0d1b946e-4b55-4d48-a37e-a97db14102e5">


