### PR TITLE
New URL for Event Sharing 

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/Events/EventShareModal.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventShareModal.js
@@ -118,7 +118,7 @@ function EventShareModal({
    */
   const sendApiRequest = () => {
     setLoading(true);
-    apiCall("/events.update", {
+    apiCall("/events.share", {
       shared_to: communitiesToShareTo.length ? communitiesToShareTo : ["reset"],
       event_id: event.id,
     })


### PR DESCRIPTION
####  Related [Issue](https://github.com/massenergize/frontend-admin/issues/1016)
closes #1016 

#### Changes
- updated event sharing url to events.share
