### PR TITLE
Host communities can see who shared

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -157,6 +157,7 @@ class AllEvents extends React.Component {
             <EventSharedState
               {...d || {}}
               classes={classes}
+              history={this.props.history}
               toggleModalOnClick={(props) => this.props.toggleModal(props)}
             />
           ),
@@ -654,10 +655,15 @@ const EventSharedState = (props) => {
     publicity,
     communities_under_publicity,
     id,
+    history,
   } = props;
 
   const numberOfSharers = shared_to?.length || 0;
   const commonClasses = "touchable-opacity";
+
+  const closeModal = () => {
+    toggleModalOnClick && toggleModalOnClick({ show: false });
+  };
 
   const notSharedYetDialog = () => {
     toggleModalOnClick &&
@@ -668,6 +674,8 @@ const EventSharedState = (props) => {
           <EventNotSharedWithAnyone
             publicity={publicity}
             shareable_to={communities_under_publicity}
+            closeModal={closeModal}
+            history={history}
             id={id}
           />
         ),
@@ -686,7 +694,10 @@ const EventSharedState = (props) => {
             publicity={publicity}
             shared_to={shared_to}
             id={id}
+            close={close}
             shareable_to={communities_under_publicity}
+            closeModal={closeModal}
+            history={history}
           />
         ),
         noOk: true,

--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -51,7 +51,10 @@ import Loader from "../../../utils/components/Loader";
 import HomeIcon from "@mui/icons-material/Home";
 import StarsIcon from "@mui/icons-material/Stars";
 import Seo from "../../../../app/components/Seo/Seo";
-import { EventNotSharedWithAnyone } from "./EventSharedStateComponents";
+import {
+  EventNotSharedWithAnyone,
+  EventSharedWithCommunity,
+} from "./EventSharedStateComponents";
 class AllEvents extends React.Component {
   constructor(props) {
     super(props);
@@ -642,13 +645,17 @@ const EventsMapped = connect(
 )(AllEvents);
 export default withStyles(styles)(withRouter(EventsMapped));
 
-const EventSharedState = ({
-  shared_to,
-  name,
-  classes,
-  toggleModalOnClick,
-  publicity,
-}) => {
+const EventSharedState = (props) => {
+  const {
+    shared_to,
+    name,
+    classes,
+    toggleModalOnClick,
+    publicity,
+    communities_under_publicity,
+    id,
+  } = props;
+
   const numberOfSharers = shared_to?.length || 0;
   const commonClasses = "touchable-opacity";
 
@@ -657,11 +664,47 @@ const EventSharedState = ({
       toggleModalOnClick({
         show: true,
         title: smartString(name, 50),
-        component: <EventNotSharedWithAnyone publicity={publicity} />,
+        component: (
+          <EventNotSharedWithAnyone
+            publicity={publicity}
+            shareable_to={communities_under_publicity}
+            id={id}
+          />
+        ),
         cancelText: "Close",
-        okText: "Change Event Settings",
+        noOk: true,
+        // okText: "Change Event Settings",
       });
   };
+  const sharedWithDialog = () => {
+    toggleModalOnClick &&
+      toggleModalOnClick({
+        show: true,
+        title: smartString(name, 50),
+        component: (
+          <EventSharedWithCommunity
+            publicity={publicity}
+            shared_to={shared_to}
+            id={id}
+            shareable_to={communities_under_publicity}
+          />
+        ),
+        noOk: true,
+        cancelText: "Close",
+        // okText: "ADD/REMOVE COMMUNITIES",
+      });
+  };
+
+  const yesProps = {
+    className: `${classes.yesLabel} ${commonClasses}`,
+    onClick: () => sharedWithDialog(),
+  };
+
+  //   const Wrapper = ({ children, style }) => (
+  //     <Typography style={style || {}} variant="body1">
+  //       {children}
+  //     </Typography>
+  //   );
 
   if (numberOfSharers === 0)
     return (
@@ -671,22 +714,16 @@ const EventSharedState = ({
         onClick={() => notSharedYetDialog()}
       />
     );
-  if (numberOfSharers === 1)
-    return (
-      <MEChip label="Yes" className={`${classes.yesLabel} ${commonClasses}`} />
-    );
+  if (numberOfSharers === 1) return <MEChip label="Yes" {...yesProps} />;
   if (numberOfSharers > 9)
-    return (
-      <MEChip className={`${classes.yesLabel} ${commonClasses}`}>
-        ({numberOfSharers})
-      </MEChip>
-    );
+    return <MEChip {...yesProps}>({numberOfSharers})</MEChip>;
   return (
-    <MEChip
-      className={`${classes.yesLabel} ${commonClasses}`}
-      containerStyle={{ padding: "0px 0px" }}
-    >
+    <MEChip {...yesProps} style={{ padding: "0px 15px" }}>
       Yes({numberOfSharers})
     </MEChip>
   );
+
+  //   <Wrapper style={{ color: "rgb(65 169 65)" }}>
+  //       <b>Yes({numberOfSharers})</b>
+  //     </Wrapper>
 };

--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -51,6 +51,7 @@ import Loader from "../../../utils/components/Loader";
 import HomeIcon from "@mui/icons-material/Home";
 import StarsIcon from "@mui/icons-material/Stars";
 import Seo from "../../../../app/components/Seo/Seo";
+import { EventNotSharedWithAnyone } from "./EventSharedStateComponents";
 class AllEvents extends React.Component {
   constructor(props) {
     super(props);
@@ -82,12 +83,13 @@ class AllEvents extends React.Component {
         initials: `${d.name && d.name.substring(0, 2).toUpperCase()}`,
       },
       smartString(d.name),
+      d,
       `${
         smartString(d.tags.map((t) => t.name).join(", "), 30) // limit to first 30 chars
       }`,
       d.is_global ? "Template" : d.community && d.community.name,
       { isLive: d.is_published, item: d },
-      { id: d.id,  is_on_home_page: d.is_on_home_page},
+      { id: d.id, is_on_home_page: d.is_on_home_page },
       d.is_published ? "Yes" : "No",
       d.is_global,
       getHumanFriendlyDate(d.start_date_and_time, true, false),
@@ -131,9 +133,7 @@ class AllEvents extends React.Component {
                   style={{ margin: 10 }}
                 />
               )}
-              {!d.image && (
-                <Avatar style={{ margin: 10 }}>{d.initials}</Avatar>
-              )}
+              {!d.image && <Avatar style={{ margin: 10 }}>{d.initials}</Avatar>}
             </div>
           ),
         },
@@ -143,6 +143,20 @@ class AllEvents extends React.Component {
         key: "name",
         options: {
           filter: false,
+        },
+      },
+      {
+        name: "Shared",
+        key: "shared",
+        options: {
+          filter: false,
+          customBodyRender: (d) => (
+            <EventSharedState
+              {...d || {}}
+              classes={classes}
+              toggleModalOnClick={(props) => this.props.toggleModal(props)}
+            />
+          ),
         },
       },
       {
@@ -197,37 +211,24 @@ class AllEvents extends React.Component {
           customBodyRender: ({ id, is_on_home_page }) => (
             <div style={{ display: "flex" }}>
               <Link to={`/admin/edit/${id}/event`}>
-                <EditIcon
-                  size="small"
-                  variant="outlined"
-                  color="secondary"
-                />
+                <EditIcon size="small" variant="outlined" color="secondary" />
               </Link>
               &nbsp;&nbsp;
               <Link
                 onClick={async () => {
-                  const copiedEventResponse = await apiCall(
-                    "/events.copy",
-                    {
-                      event_id: id,
-                    }
-                  );
+                  const copiedEventResponse = await apiCall("/events.copy", {
+                    event_id: id,
+                  });
                   if (copiedEventResponse && copiedEventResponse.success) {
                     const newEvent =
                       copiedEventResponse && copiedEventResponse.data;
-                    this.props.history.push(
-                      `/admin/edit/${newEvent.id}/event`
-                    );
+                    this.props.history.push(`/admin/edit/${newEvent.id}/event`);
                     putEventsInRedux([newEvent, ...(allEvents || [])]);
                   }
                 }}
                 to="/admin/read/events"
               >
-                <FileCopy
-                  size="small"
-                  variant="outlined"
-                  color="secondary"
-                />
+                <FileCopy size="small" variant="outlined" color="secondary" />
               </Link>
               {auth && auth.is_super_admin && (
                 <Link to={`/admin/read/event/${id}/event-view?from=main`}>
@@ -369,7 +370,8 @@ class AllEvents extends React.Component {
   addEventToHomePage = (id) => {
     const { allEvents, putEventsInRedux } = this.props;
     const data = allEvents || [];
-    let event =data?.find((item) => item.id?.toString() === id?.toString()) || {};
+    let event =
+      data?.find((item) => item.id?.toString() === id?.toString()) || {};
     const index = data.findIndex((a) => a.id?.toString() === id);
 
     const toSend = {
@@ -386,10 +388,10 @@ class AllEvents extends React.Component {
       });
       return;
     }
-  
+
     apiCall("home_page_settings.addEvent", toSend).then((res) => {
       if (res.success) {
-        event.is_on_home_page = res?.data?.status
+        event.is_on_home_page = res?.data?.status;
         data.splice(index, 1, event);
         putEventsInRedux([...data]);
         this.props.toggleToast({
@@ -564,7 +566,7 @@ class AllEvents extends React.Component {
           return f[9]; // this index should be changed if anyone modifies (adds/removes) an item in fashioData()
         });
         const noTemplatesSelectedGoAhead = !found || !found.length;
-        this.props.toggleDeleteConfirmation({
+        this.props.toggleModal({
           show: true,
           component: makeDeleteUI({
             idsToDelete,
@@ -625,7 +627,7 @@ function mapDispatchToProps(dispatch) {
       callForSuperAdminEvents: reduxGetAllEvents,
       callForNormalAdminEvents: reduxGetAllCommunityEvents,
       putEventsInRedux: loadAllEvents,
-      toggleDeleteConfirmation: reduxToggleUniversalModal,
+      toggleModal: reduxToggleUniversalModal,
       toggleLive: reduxToggleUniversalModal,
       toggleToast: reduxToggleUniversalToast,
       putMetaDataToRedux: reduxLoadMetaDataAction,
@@ -639,3 +641,52 @@ const EventsMapped = connect(
   mapDispatchToProps
 )(AllEvents);
 export default withStyles(styles)(withRouter(EventsMapped));
+
+const EventSharedState = ({
+  shared_to,
+  name,
+  classes,
+  toggleModalOnClick,
+  publicity,
+}) => {
+  const numberOfSharers = shared_to?.length || 0;
+  const commonClasses = "touchable-opacity";
+
+  const notSharedYetDialog = () => {
+    toggleModalOnClick &&
+      toggleModalOnClick({
+        show: true,
+        title: smartString(name, 50),
+        component: <EventNotSharedWithAnyone publicity={publicity} />,
+        cancelText: "Close",
+        okText: "Change Event Settings",
+      });
+  };
+
+  if (numberOfSharers === 0)
+    return (
+      <MEChip
+        label="No"
+        className={`${classes.noLabel} ${commonClasses}`}
+        onClick={() => notSharedYetDialog()}
+      />
+    );
+  if (numberOfSharers === 1)
+    return (
+      <MEChip label="Yes" className={`${classes.yesLabel} ${commonClasses}`} />
+    );
+  if (numberOfSharers > 9)
+    return (
+      <MEChip className={`${classes.yesLabel} ${commonClasses}`}>
+        ({numberOfSharers})
+      </MEChip>
+    );
+  return (
+    <MEChip
+      className={`${classes.yesLabel} ${commonClasses}`}
+      containerStyle={{ padding: "0px 0px" }}
+    >
+      Yes({numberOfSharers})
+    </MEChip>
+  );
+};

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventFullView.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventFullView.js
@@ -249,6 +249,7 @@ function EventFullView(props) {
         toggleModal={setshowShareModal}
         event={event}
         updateEventInHeap={putEventInHeap}
+        hasControl = {hasControl}
         otherEvents={events}
         myEvents={myEvents}
         updateNormalEventListInRedux={putEventsInRedux}

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventFullView.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventFullView.js
@@ -30,12 +30,14 @@ const close = {
 };
 export const PUBLICITY_PROPS = {
   OPEN: {
+    icon: "fa-globe",
     style: open,
     info: "This event/campaign can be shared to any community",
     label: "Open",
     tooltip: "Share with any community",
   },
   OPEN_TO: {
+    icon: "fa-users",
     style: open,
     info:
       "This event/campaign can only be shared with the listed communities below",
@@ -43,6 +45,7 @@ export const PUBLICITY_PROPS = {
     tooltip: "Share with a few selected",
   },
   CLOSE: {
+    icon: "fa-lock",
     style: close,
     info:
       "This event/compaign is closed. It can't be shared with any community",
@@ -50,13 +53,24 @@ export const PUBLICITY_PROPS = {
     tooltip: "Cannot be shared",
   },
   CLOSED_TO: {
+    icon: "fa-users",
     style: { ...close, background: "#e79157" },
     info: "This event/campaign is only closed to the communities listed below",
     label: "Closed To",
     tooltip: "Open to all except a few listed",
   },
 };
+export const listToString = (list) => {
+  if (!list || !list.length) return "";
 
+  var str = "";
+  for (var i in list) {
+    const com = list[i];
+    if (Number(i) === 0) str += com.name;
+    else str += `, ${com.name}`;
+  }
+  return str;
+};
 function EventFullView(props) {
   const {
     events,
@@ -183,17 +197,6 @@ function EventFullView(props) {
       });
   };
 
-  const listToString = (list) => {
-    if (!list || !list.length) return "";
-
-    var str = "";
-    for (var i in list) {
-      const com = list[i];
-      if (Number(i) === 0) str += com.name;
-      else str += `, ${com.name}`;
-    }
-    return str;
-  };
   //   ----------------------------------------------------------------------------------------
   const pageIsLoading = event === undefined;
   const couldNotFindEvent = event === null;
@@ -237,12 +240,12 @@ function EventFullView(props) {
   };
   return (
     <div>
-      <Seo name={`Full View - ${event?.name}`}/>
+      <Seo name={`Full View - ${event?.name}`} />
       <EventShareModal
         auth={auth}
         communities={communities}
         show={showShareModal}
-        close = {()=> setshowShareModal(false)}
+        close={() => setshowShareModal(false)}
         toggleModal={setshowShareModal}
         event={event}
         updateEventInHeap={putEventInHeap}
@@ -336,7 +339,7 @@ function EventFullView(props) {
         </div>
       </Paper>
 
-      <EditEventForm passedEvent = {event} />
+      <EditEventForm passedEvent={event} />
     </div>
   );
 }

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventFullView.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventFullView.js
@@ -28,7 +28,7 @@ const open = {
 const close = {
   background: "#d87c7b",
 };
-const PUBLICITY_PROPS = {
+export const PUBLICITY_PROPS = {
   OPEN: {
     style: open,
     info: "This event/campaign can be shared to any community",

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventShareModal.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventShareModal.js
@@ -127,7 +127,7 @@ function EventShareModal({
         if (!response.success)
           return console.log("SHARING_ERROR_BE:", response.error);
 
-        close && close()
+        close && close();
         setCommunities([]);
         setChanged(false);
 
@@ -172,6 +172,7 @@ function EventShareModal({
   return (
     <div>
       <ThemeModal
+        noTitle
         open={show}
         fullControl
         close={() => toggleModal && toggleModal(false)}

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventShareModal.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventShareModal.js
@@ -25,6 +25,7 @@ function EventShareModal({
   updateEventInHeap,
   updateOtherEventListInRedux,
   updateNormalEventListInRedux,
+  hasControl,
 }) {
   const [communitiesToShareTo, setCommunities] = useState([]); // Selected communities to share to
   const [changed, setChanged] = useState(false);
@@ -53,14 +54,27 @@ function EventShareModal({
    * @returns
    */
   const getAllowedCommunities = () => {
-    const { is_open, is_open_to, communities_under_publicity, is_closed_to } =
-      event || {};
+    const {
+      is_open,
+      is_open_to,
+      communities_under_publicity,
+      is_closed_to,
+      shared_to,
+    } = event || {};
+
     const allowedCommunities = (communities_under_publicity || []).map(
       (c) => c.id
     );
     const adminCommunities = (auth && auth.admin_at) || [];
-    // Event is open and user is a cadmin, they can share to any of their communities
-    if (is_open && isCommunityAdmin) return (auth && auth.admin_at) || [];
+
+    // Event is open or open_to and user is a cadmin (also owner of the event) then
+    // it should show communities that have shared it(so they can remove)
+    if ((is_open || is_open_to) && isCommunityAdmin && hasControl)
+      return shared_to || [];
+
+    // Event is open and user is a cadmin(not owner), they can share to any of their communities
+    if (is_open && isCommunityAdmin && !hasControl)
+      return (auth && auth.admin_at) || [];
     // Event is open and use is a super admin, they can share to any commmunity on the site
     if (is_open && isSuperAdmin) return communities || [];
     // Event is only open to a selection of communities, check the admin's community list
@@ -97,20 +111,6 @@ function EventShareModal({
     }
 
     return [];
-  };
-
-  const groupTheOptions = () => {
-    const allowed = getAllowedCommunities();
-    // Collect all communities that this event has been shared to
-    var sharedTo = (event || {}).shared_to || [];
-    var alreadySharedTo = sharedTo.map((c) => c.id);
-    // Given the allowed communities based on the admin's communties(they manage), only retrieve the communities that the event has not been shared to
-    var shareTo = allowed.filter((c) => !alreadySharedTo.includes(c.id));
-    const shareIds = shareTo.map((c) => c.id);
-
-    var unShare = allowed.filter((c) => !shareIds.includes(c.id));
-
-    return { shareTo, unShare };
   };
 
   /**
@@ -288,8 +288,7 @@ const ShareWith = ({ communities, addSelected, selected }) => {
         variant="caption"
         style={{ padding: 15, textAlign: "center", color: "grey" }}
       >
-        No communities on this list, you must have shared this to all available
-        communities already
+        None of the communities you manage are on the list...
       </Typography>
     );
   }
@@ -306,32 +305,6 @@ const ShareWith = ({ communities, addSelected, selected }) => {
               checked={selected.includes(comm.id)}
             />
           }
-          label={comm.name}
-        />
-      </div>
-    );
-  });
-};
-
-const UnShare = ({ communities, addSelected }) => {
-  if (!communities || !communities.length) {
-    return (
-      <Typography
-        variant="caption"
-        style={{ padding: 15, textAlign: "center", color: "grey" }}
-      >
-        If you already shared to a community on your list, it will appear here
-      </Typography>
-    );
-  }
-  (communities || []).sort((a, b) => (a.name < b.name ? -1 : 1));
-
-  return communities.map((comm, index) => {
-    return (
-      <div style={{ width: "50%" }} key={index.toString()}>
-        <FormControlLabel
-          key={index.toString()}
-          control={<Checkbox onChange={(e) => addSelected(comm.id)} />}
           label={comm.name}
         />
       </div>

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
@@ -88,7 +88,7 @@ export const EventSharedWithCommunity = ({
           }}
           // to={`/admin/edit/${id}/event`}
         >
-          Change who can we this event
+          Change who can see this event
         </Link>
       </div>
     </div>

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
@@ -1,0 +1,18 @@
+import { Typography } from "@mui/material";
+import React from "react";
+import { PUBLICITY_PROPS } from "./EventFullView";
+
+export const EventNotSharedWithAnyone = ({ publicity }) => {
+  const pub = PUBLICITY_PROPS[publicity];
+  console.log("These are the props", pub);
+  return (
+    <div style={{}}>
+      <Typography>
+        This event has not been shared by any communities yet.
+      </Typography>
+      <Typography variant="body">
+        <b style={{ color: pub?.style?.background }}>{pub?.info}</b>{" "}
+      </Typography>
+    </div>
+  );
+};

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
@@ -33,7 +33,7 @@ export const EventNotSharedWithAnyone = ({
             history.push(`/admin/edit/${id}/event`);
           }}
         >
-          Change Who Can See This Event
+          Change who can see this event
         </Link>
       </div>
     </div>

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
@@ -3,7 +3,13 @@ import React from "react";
 import { PUBLICITY_PROPS, listToString } from "./EventFullView";
 import { Link } from "react-router-dom/cjs/react-router-dom";
 
-export const EventNotSharedWithAnyone = ({ publicity, shareable_to, id }) => {
+export const EventNotSharedWithAnyone = ({
+  publicity,
+  shareable_to,
+  id,
+  closeModal,
+  history,
+}) => {
   const pub = PUBLICITY_PROPS[publicity];
   return (
     <div style={{}}>
@@ -20,7 +26,13 @@ export const EventNotSharedWithAnyone = ({ publicity, shareable_to, id }) => {
       </Typography>
 
       <div style={{ marginTop: 10 }}>
-        <Link to={`/admin/edit/${id}/event`}>
+        <Link
+          onClick={(e) => {
+            e.preventDefault();
+            closeModal();
+            history.push(`/admin/edit/${id}/event`);
+          }}
+        >
           Change Who Can See This Event
         </Link>
       </div>
@@ -29,9 +41,12 @@ export const EventNotSharedWithAnyone = ({ publicity, shareable_to, id }) => {
 };
 
 export const EventSharedWithCommunity = ({
+  id,
   publicity,
   shared_to,
   shareable_to,
+  closeModal,
+  history,
 }) => {
   const pub = PUBLICITY_PROPS[publicity];
   return (
@@ -42,14 +57,40 @@ export const EventSharedWithCommunity = ({
       <Typography>
         <b>{listToString(shared_to)}</b>
       </Typography>
+      <div style={{ marginTop: 10 }}>
+        <Link
+          onClick={(e) => {
+            e.preventDefault();
+            closeModal();
+            history.push(`/admin/read/event/${id}/event-view?dialog=open`);
+          }}
+
+          // to={`/admin/read/event/${id}/event-view?dialog=open`}
+        >
+          Add/Remove communities from shared list
+        </Link>
+      </div>
       <br />
       <Typography variant="body1" style={{ color: pub?.style?.background }}>
         <i className={`fa ${pub?.icon || ""}`} style={{ marginRight: 6 }} />
-        <span>{pub?.info}:</span>{" "}
+        <span>{pub?.info}</span>{" "}
       </Typography>
       <Typography>
         <b>{listToString(shareable_to)}</b>
       </Typography>
+
+      <div style={{ marginTop: 10 }}>
+        <Link
+          onClick={(e) => {
+            e.preventDefault();
+            closeModal();
+            history.push(`/admin/edit/${id}/event`);
+          }}
+          // to={`/admin/edit/${id}/event`}
+        >
+          Change who can we this event
+        </Link>
+      </div>
     </div>
   );
 };

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventSharedStateComponents.js
@@ -1,17 +1,54 @@
 import { Typography } from "@mui/material";
 import React from "react";
-import { PUBLICITY_PROPS } from "./EventFullView";
+import { PUBLICITY_PROPS, listToString } from "./EventFullView";
+import { Link } from "react-router-dom/cjs/react-router-dom";
 
-export const EventNotSharedWithAnyone = ({ publicity }) => {
+export const EventNotSharedWithAnyone = ({ publicity, shareable_to, id }) => {
   const pub = PUBLICITY_PROPS[publicity];
-  console.log("These are the props", pub);
   return (
     <div style={{}}>
-      <Typography>
-        This event has not been shared by any communities yet.
+      <Typography style={{ marginBottom: 10 }}>
+        This event has not been shared to any communities yet.
       </Typography>
-      <Typography variant="body">
-        <b style={{ color: pub?.style?.background }}>{pub?.info}</b>{" "}
+
+      <Typography variant="body1" style={{ color: pub?.style?.background }}>
+        <i className={`fa ${pub?.icon || ""}`} style={{ marginRight: 6 }} />
+        <span>{pub?.info}</span>{" "}
+      </Typography>
+      <Typography>
+        <b>{listToString(shareable_to)}</b>
+      </Typography>
+
+      <div style={{ marginTop: 10 }}>
+        <Link to={`/admin/edit/${id}/event`}>
+          Change Who Can See This Event
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export const EventSharedWithCommunity = ({
+  publicity,
+  shared_to,
+  shareable_to,
+}) => {
+  const pub = PUBLICITY_PROPS[publicity];
+  return (
+    <div style={{}}>
+      <Typography variant="body1">
+        This event is currently shared to the following communities:
+      </Typography>
+      <Typography>
+        <b>{listToString(shared_to)}</b>
+      </Typography>
+      <br />
+      <Typography variant="body1" style={{ color: pub?.style?.background }}>
+        <i className={`fa ${pub?.icon || ""}`} style={{ marginRight: 6 }} />
+        <span>{pub?.info}:</span>{" "}
+      </Typography>
+      <Typography>
+        <b>{listToString(shareable_to)}</b>
       </Typography>
     </div>
   );

--- a/app/styles/ME Custom/extra.css
+++ b/app/styles/ME Custom/extra.css
@@ -94,6 +94,7 @@
   font-size: 11px;
   align-items: center;
   justify-content: center;
+  margin: 0px;
 }
 
 .me-chip-container {


### PR DESCRIPTION
### Related ticket https://github.com/massenergize/frontend-admin/issues/816

- [X] There is now a new column on the "my events" page that says "shared" that shows a "Yes/No" based on the event's shared status. 

- [X] If shared, it says "Yes(with number of coms shared to)" as requested. 
see here: 
![Screenshot 2023-07-03 at 09 41 43](https://github.com/massenergize/frontend-admin/assets/26961591/2c4c4598-e3eb-4aa1-926d-c0ff8496dced)


- [X] If shared, when you click, it shows you which communities the event has been shared to with a few other things. See here: 
![Screenshot 2023-07-03 at 09 42 58](https://github.com/massenergize/frontend-admin/assets/26961591/0e1d38a0-eb37-45c8-8ec1-b895a2f30b82)
- [X] When the event is not shared, it still opens a dialog that tells you the event's publicity status, and provides a link that will take you to the event edit page where you can change it, if  need be... 
see here: 


![Screenshot 2023-07-03 at 11 05 20](https://github.com/massenergize/frontend-admin/assets/26961591/dafd0de7-6b1c-44e1-a935-bfd1cc2ad8b3)
![Screenshot 2023-07-03 at 11 05 12](https://github.com/massenergize/frontend-admin/assets/26961591/53f7fe9c-94f5-4fea-bd04-aa7c627c2bd6)


- [X]  And yes, in the event share dialog, if the admin owns the event. It will now show the communities that the event has been shared to, so they can edit. (as a community admin)





DEMO 


https://github.com/massenergize/frontend-admin/assets/26961591/7c500e52-4139-48db-9606-deeca148a059








