### PR TITLE
TinyMCE now works with image selection from our Media Library

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.js
+++ b/app/containers/MassEnergizeSuperAdmin/ME  Tools/media library/MediaLibrary.js
@@ -24,8 +24,9 @@ function MediaLibrary(props) {
     images,
     defaultTab,
     dragToOrder,
+    floatingMode,
   } = props;
-  const [show, setShow] = useState(openState);
+  const [show, setShow] = useState(false);
   const [imageTray, setTrayImages] = useState([]);
   const [state, setState] = useState({});
   const [hasMounted, setHasMountedTo] = useState(undefined);
@@ -69,6 +70,10 @@ function MediaLibrary(props) {
     setTrayImages(rest);
     transfer(rest, state.resetor);
   };
+
+  useEffect(() => {
+    setShow(openState);
+  }, [openState]);
 
   useEffect(() => {
     const isMountingForTheFirstTime = hasMounted === undefined;
@@ -150,54 +155,56 @@ function MediaLibrary(props) {
         </div>
       )}
 
-      <div
-        style={{
-          width: "100%",
-          minHeight: 380,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          flexDirection: "column",
-          border: "dashed 2px #e3e3e3",
-          borderRadius: 10,
-          marginBottom: 20,
-          padding: 20,
-        }}
-      >
-        {!imageTray || imageTray.length === 0 ? (
-          <img src={libraryImage} style={{ height: 150 }} />
-        ) : (
-          <ImageTray
-            sourceExtractor={sourceExtractor}
-            content={imageTray}
-            remove={remove}
-            multiple={multiple}
-            dragToOrder={dragToOrder}
-            oldPosition={oldPosition}
-            newPosition={newPosition}
-            swapPositions={swapPositions}
-
-            // switchToCropping={switchToCropping}
-          />
-        )}
-
+      {!floatingMode && (
         <div
-          onClick={(e) => {
-            e.preventDefault();
-            setShow(true);
-          }}
-          className={`ml-footer-btn `}
           style={{
-            "--btn-color": "white",
-            "--btn-background": "green",
-            borderRadius: 5,
-            marginTop: 20,
-            padding: "15px 40px",
+            width: "100%",
+            minHeight: 380,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexDirection: "column",
+            border: "dashed 2px #e3e3e3",
+            borderRadius: 10,
+            marginBottom: 20,
+            padding: 20,
           }}
         >
-          {actionText}
+          {!imageTray || imageTray.length === 0 ? (
+            <img src={libraryImage} style={{ height: 150 }} />
+          ) : (
+            <ImageTray
+              sourceExtractor={sourceExtractor}
+              content={imageTray}
+              remove={remove}
+              multiple={multiple}
+              dragToOrder={dragToOrder}
+              oldPosition={oldPosition}
+              newPosition={newPosition}
+              swapPositions={swapPositions}
+
+              // switchToCropping={switchToCropping}
+            />
+          )}
+
+          <div
+            onClick={(e) => {
+              e.preventDefault();
+              setShow(true);
+            }}
+            className={`ml-footer-btn `}
+            style={{
+              "--btn-color": "white",
+              "--btn-background": "green",
+              borderRadius: 5,
+              marginTop: 20,
+              padding: "15px 40px",
+            }}
+          >
+            {actionText}
+          </div>
         </div>
-      </div>
+      )}
     </React.Fragment>
   );
 }
@@ -405,6 +412,11 @@ MediaLibrary.propTypes = {
    * A function that should return a tooltip component.
    */
   TooltipWrapper: PropTypes.string,
+  /**
+   * In some situations, the tray images that display when a user has inserted an images from the mlibrary, is not needed. Typical example is how mlib is being used in TinyMCE
+   * So, this value is used to toggle the image tray ON/OFF. (true = No image Tray)
+   */
+  floatingMode: PropTypes.bool,
 };
 
 MediaLibrary.Button = MLButton;
@@ -432,5 +444,6 @@ MediaLibrary.defaultProps = {
   compressedQuality: IMAGE_QUALITY.MEDIUM.key,
   maximumImageSize: DEFFAULT_MAX_SIZE,
   renderBeforeImages: null,
+  floatingMode: false,
 };
 export default MediaLibrary;

--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/TinyMassEnergizeEditor.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/TinyMassEnergizeEditor.js
@@ -11,9 +11,10 @@ function TinyMassEnergizeEditor(props) {
 
   useEffect(() => {
     if (!image || !editor) return;
-    editor.insertContent(
-      `<img style='object-fit:contain;' src="${image}" alt="Google Image" />`
-    );
+    editor.insertContent &&
+      editor.insertContent(
+        `<img style='object-fit:contain;' src="${image}" alt="Google Image" />`
+      );
   }, [image]);
 
   const config = {
@@ -34,6 +35,7 @@ function TinyMassEnergizeEditor(props) {
       <FormMediaLibraryImplementation
         onStateChange={({ show }) => setOpen(show)}
         openState={open}
+        defaultTab="library"
         onInsert={(files) => {
           const img = (files || [])[0];
           setImage(img?.url);
@@ -41,6 +43,10 @@ function TinyMassEnergizeEditor(props) {
         floatingMode
       />
       <TinyEditor
+        onInit={(editor) => {
+          let ed = editor?.target?.editorCommands || {};
+          setEditor(ed?.editor);
+        }}
         {...props}
         onEditorChange={handleEditorChange}
         toolbar="undo redo | blocks | formatselect | media_library | bold italic backcolor forecolor | alignleft aligncenter alignright alignjustify | link | bullist numlist outdent indent | fontfamily | fontsize |"

--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/TinyMassEnergizeEditor.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/TinyMassEnergizeEditor.js
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+import { Editor as TinyEditor } from "@tinymce/tinymce-react";
+import FormMediaLibraryImplementation from "./FormMediaLibraryImplementation";
+const TINY_MCE_API_KEY = process.env.REACT_APP_TINY_MCE_KEY;
+
+function TinyMassEnergizeEditor(props) {
+  const [open, setOpen] = useState(false);
+  const [image, setImage] = useState(null);
+  const [editor, setEditor] = useState(null);
+  const { onEditorChange } = props;
+
+  useEffect(() => {
+    if (!image || !editor) return;
+    editor.insertContent(
+      `<img style='object-fit:contain;' src="${image}" alt="Google Image" />`
+    );
+  }, [image]);
+
+  const config = {
+    setup: (editor) => {
+      editor.ui.registry.addButton("media_library", {
+        text: "Media Library",
+        onAction: () => setOpen(true),
+      });
+    },
+  };
+  const handleEditorChange = (content, _editor) => {
+    setEditor(_editor);
+    if (!onEditorChange) return;
+    onEditorChange(content, _editor);
+  };
+  return (
+    <div>
+      <FormMediaLibraryImplementation
+        onStateChange={({ show }) => setOpen(show)}
+        openState={open}
+        onInsert={(files) => {
+          const img = (files || [])[0];
+          setImage(img?.url);
+        }}
+        floatingMode
+      />
+      <TinyEditor
+        {...props}
+        onEditorChange={handleEditorChange}
+        toolbar="undo redo | blocks | formatselect | media_library | bold italic backcolor forecolor | alignleft aligncenter alignright alignjustify | link | bullist numlist outdent indent | fontfamily | fontsize |"
+        plugins="advlist media_library autolink lists link charmap print preview anchor forecolor"
+        init={{
+          height: 350,
+          menubar: false,
+          default_link_target: "_blank",
+          force_br_newlines: true,
+          force_p_newlines: false,
+          forced_root_block: "", // Needed for 3.x
+          ...config,
+        }}
+        apiKey={TINY_MCE_API_KEY}
+      />
+    </div>
+  );
+}
+
+export default TinyMassEnergizeEditor;

--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
@@ -1062,8 +1062,10 @@ class MassEnergizeForm extends Component {
                   this.handleEditorChange(content, editor, field.name);
                 }}
                 // Toolbar Docs:  https://www.tiny.cloud/docs/tinymce/6/migration-from-5x/#things-we-renamed
-                toolbar="undo redo | blocks | formatselect | bold italic backcolor forecolor | alignleft aligncenter alignright alignjustify | link | image | bullist numlist outdent indent | fontfamily | fontsize |"
-                plugins="advlist autolink lists link image charmap print preview anchor forecolor"
+                // toolbar="undo redo | blocks | formatselect | media_library | bold italic backcolor forecolor | alignleft aligncenter alignright alignjustify | link | image | bullist numlist outdent indent | fontfamily | fontsize |"
+                // plugins="advlist media_library autolink lists link image charmap print preview anchor forecolor"
+                toolbar="undo redo | blocks | formatselect | media_library | bold italic backcolor forecolor | alignleft aligncenter alignright alignjustify | link | bullist numlist outdent indent | fontfamily | fontsize |"
+                plugins="advlist media_library autolink lists link charmap print preview anchor forecolor"
                 init={{
                   height: 350,
                   menubar: false,
@@ -1079,6 +1081,13 @@ class MassEnergizeForm extends Component {
                   //   );
                   //   freeTiny.style.display = "none";
                   // },
+                  setup: (editor) => {
+                    editor.ui.registry.addButton("media_library", {
+                      text: "Media Library",
+                      onAction: () =>
+                        console.log("I am the trigger for the media library!"),
+                    });
+                  },
                 }}
                 apiKey={TINY_MCE_API_KEY}
               />

--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/index.js
@@ -25,7 +25,9 @@ import { Link, withRouter } from "react-router-dom";
 import { MaterialDropZone } from "dan-components";
 import Snackbar from "@mui/material/Snackbar";
 import CircularProgress from "@mui/material/CircularProgress";
-import { Editor as TinyEditor } from "@tinymce/tinymce-react";
+// import { Editor as TinyEditor } from "@tinymce/tinymce-react";
+import TinyEditor from "./TinyMassEnergizeEditor";
+
 import { MenuItem, Alert } from "@mui/material";
 import TextField from "@mui/material/TextField";
 // import Icon from '@mui/material/Icon';
@@ -1030,30 +1032,23 @@ class MassEnergizeForm extends Component {
               <div style={{ padding: 20, color: "#d28818" }}>
                 <Typography>{field.label}</Typography>
                 <small>
-                  <b>PLEASE NOTE:</b> the wide spacing between two lines
-                  in the editor, is not what you will get when you
-                  content gets to users.
+                  <b>PLEASE NOTE:</b> the wide spacing between two lines in the
+                  editor, is not what you will get when you content gets to
+                  users.
                   <br />
                   If you need a{" "}
                   <b>
                     <i>gap </i>
                   </b>
-                  between two lines, press your <b>Enter Key twice </b>{" "}
-                  or more, instead of <b>once</b>
+                  between two lines, press your <b>Enter Key twice </b> or more,
+                  instead of <b>once</b>
                   <br />
                   <b>
-                    Pressing Once, will only show items right on the
-                    next line, without any gap
+                    Pressing Once, will only show items right on the next line,
+                    without any gap
                   </b>
                 </small>
               </div>
-              {/* <Editor
-                editorState={this.getValue(field.name, EditorState.createEmpty())}
-                editorClassName="editorClassName"
-                onEditorStateChange={(e) => this.onEditorStateChange(field.name, e)}
-                toolbarClassName="toolbarClassName"
-                wrapperClassName="wrapperClassName"
-              /> */}
 
               <TinyEditor
                 id={field?.name || "" + field?.dbName || ""}
@@ -1061,35 +1056,6 @@ class MassEnergizeForm extends Component {
                 onEditorChange={(content, editor) => {
                   this.handleEditorChange(content, editor, field.name);
                 }}
-                // Toolbar Docs:  https://www.tiny.cloud/docs/tinymce/6/migration-from-5x/#things-we-renamed
-                // toolbar="undo redo | blocks | formatselect | media_library | bold italic backcolor forecolor | alignleft aligncenter alignright alignjustify | link | image | bullist numlist outdent indent | fontfamily | fontsize |"
-                // plugins="advlist media_library autolink lists link image charmap print preview anchor forecolor"
-                toolbar="undo redo | blocks | formatselect | media_library | bold italic backcolor forecolor | alignleft aligncenter alignright alignjustify | link | bullist numlist outdent indent | fontfamily | fontsize |"
-                plugins="advlist media_library autolink lists link charmap print preview anchor forecolor"
-                init={{
-                  height: 350,
-                  menubar: false,
-                  default_link_target: "_blank",
-                  force_br_newlines: true,
-                  force_p_newlines: false,
-                  forced_root_block: "", // Needed for 3.x
-                  // next 4 lines test to eliminate tiny cloud errors
-                  // selector: "textarea",
-                  // init_instance_callback: function(editor) {
-                  //   var freeTiny = document.querySelector(
-                  //     ".tox .tox-notification--in"
-                  //   );
-                  //   freeTiny.style.display = "none";
-                  // },
-                  setup: (editor) => {
-                    editor.ui.registry.addButton("media_library", {
-                      text: "Media Library",
-                      onAction: () =>
-                        console.log("I am the trigger for the media library!"),
-                    });
-                  },
-                }}
-                apiKey={TINY_MCE_API_KEY}
               />
             </Grid>
             <br />


### PR DESCRIPTION
Related ticket #1070  

@kaatvds  @BradHN1 
I have treated this as a different ticket from the other media library developments. 


- [X] Now, you can insert an image by  selecting an item from the media library. After inserting, you have all the edit capabalities that already TinyMCE provides for all image insertions. Resizing, textwrap, etc... 

## DEMO 



https://github.com/massenergize/frontend-admin/assets/26961591/3ae9b752-f5c1-4e8a-a7c5-25fb4a545819

