### PR TITLE
Fixed auto image selection right after upload in Mlibrary

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/_FormGenerator/media library/FormMediaLibraryImplementation.js
+++ b/app/containers/MassEnergizeSuperAdmin/_FormGenerator/media library/FormMediaLibraryImplementation.js
@@ -95,7 +95,7 @@ export const FormMediaLibraryImplementation = (props) => {
   };
 
   useEffect(() => {
-    if (mounted) return;
+    if (mounted) return useIdsToFindObjs(selected);
     // The value of "preselected" could either be a list of numbers(ids), or a list of objects(json image objects from backend)
     // This happens because when the page loads afresh, and we pass down images as default value in some "formGenerator JSON", it comes in as objects
     // But then when the user goes around and selects images from the library, the form generator is setup to only


### PR DESCRIPTION
Not a ticket. I was working on something else and found this bug. 



- [X] Run the code in development right now. You will notice that right after you upload in the media library, the image is not preselected. This PR fixes that.

DEMO 

https://github.com/massenergize/frontend-admin/assets/26961591/259aeb51-1c9d-4161-a16b-0f8cb132dc8d


