### PR TITLE
Fix/paginated data fetching and update default items per page

### DIFF
--- a/app/containers/MassEnergizeSuperAdmin/Actions/ActionUsers.js
+++ b/app/containers/MassEnergizeSuperAdmin/Actions/ActionUsers.js
@@ -17,6 +17,7 @@ import { useParams } from "react-router-dom/cjs/react-router-dom.min";
 import { getHumanFriendlyDate } from "../../../utils/common";
 import { apiCall } from "../../../utils/messenger";
 import Loader from "../../../utils/components/Loader";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 function ActionUsers({ classes }) {
   const title = brand.name + " - Action Users";
@@ -103,8 +104,8 @@ function ActionUsers({ classes }) {
     filterType: "dropdown",
     responsive: "standard",
     print: true,
-    rowsPerPage: 25,
-    rowsPerPageOptions: [10, 25, 100],
+    rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+    rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
     downloadOptions: {
       filename: `${action?.title}- Action Users.csv`,
       separator: ",",

--- a/app/containers/MassEnergizeSuperAdmin/Actions/AllActions.js
+++ b/app/containers/MassEnergizeSuperAdmin/Actions/AllActions.js
@@ -50,6 +50,7 @@ import Loader from "../../../utils/components/Loader";
 import PeopleIcon from "@mui/icons-material/People";
 import Seo from '../../../../app/components/Seo/Seo'
 import CustomOptions from "../ME  Tools/table /CustomOptions";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 class AllActions extends React.Component {
   constructor(props) {
@@ -222,7 +223,7 @@ class AllActions extends React.Component {
               label:"community",
               endpoint:"/communities.listForSuperAdmin"
             })
-          : 
+          :
           {
               filter: true,
               filterType: "multiselect",
@@ -529,9 +530,9 @@ class AllActions extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
       count: metaData && metaData.count,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       onTableChange: (action, tableState) =>
         onTableStateChange({

--- a/app/containers/MassEnergizeSuperAdmin/CarbonEquivalencies/AllCarbonEquivalencies.js
+++ b/app/containers/MassEnergizeSuperAdmin/CarbonEquivalencies/AllCarbonEquivalencies.js
@@ -17,6 +17,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Typography } from '@mui/material';
 import Seo from '../../../components/Seo/Seo';
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 
 class AllCarbonEquivalencies extends React.Component {
@@ -140,8 +141,8 @@ class AllCarbonEquivalencies extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       onRowsDelete: (rowsDeleted) => {
         const idsToDelete = rowsDeleted.data;
         this.props.toggleDeleteConfirmation({

--- a/app/containers/MassEnergizeSuperAdmin/Categories/AllCategories.js
+++ b/app/containers/MassEnergizeSuperAdmin/Categories/AllCategories.js
@@ -27,6 +27,7 @@ import METable from "../ME  Tools/table /METable";
 import { isEmpty } from "../../../utils/common";
 import Loader from "../../../utils/components/Loader";
 import Seo from "../../../components/Seo/Seo";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 class AllTagCollections extends React.Component {
   constructor(props) {
     super(props);
@@ -203,8 +204,8 @@ class AllTagCollections extends React.Component {
       responsive: "standard",
       count: metaData && metaData.count,
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       onRowsDelete: (rowsDeleted) => {
         const idsToDelete = rowsDeleted.data;
         this.props.toggleDeleteConfirmation({

--- a/app/containers/MassEnergizeSuperAdmin/Community/AddRemoveAdmin.js
+++ b/app/containers/MassEnergizeSuperAdmin/Community/AddRemoveAdmin.js
@@ -8,7 +8,7 @@ import MassEnergizeForm from "../_FormGenerator";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { reduxLoadAdmins } from "../../../redux/redux-actions/adminActions";
-import { LOADING } from "../../../utils/constants";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS, LOADING } from '../../../utils/constants';
 import Loading from "dan-components/Loading";
 import MEChip from "../../../components/MECustom/MEChip";
 import Seo from "../../../components/Seo/Seo";
@@ -185,8 +185,8 @@ class AddRemoveAdmin extends Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       onRowsDelete: (rowsDeleted) => {
         const idsToDelete = rowsDeleted.data;
         const { pathname } = window.location;

--- a/app/containers/MassEnergizeSuperAdmin/Community/AddRemoveSuperAdmin.js
+++ b/app/containers/MassEnergizeSuperAdmin/Community/AddRemoveSuperAdmin.js
@@ -9,7 +9,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { reduxLoadSuperAdmins } from "../../../redux/redux-actions/adminActions";
 import Loading from "dan-components/Loading";
-import { LOADING } from "../../../utils/constants";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS, LOADING } from '../../../utils/constants';
 import Seo from "../../../components/Seo/Seo";
 const styles = (theme) => ({
   root: {
@@ -152,8 +152,8 @@ class AddRemoveSuperAdmin extends Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       onRowsDelete: (rowsDeleted) => {
         const idsToDelete = rowsDeleted.data;
         const { pathname } = window.location;

--- a/app/containers/MassEnergizeSuperAdmin/Community/AllCommunities.js
+++ b/app/containers/MassEnergizeSuperAdmin/Community/AllCommunities.js
@@ -27,6 +27,7 @@ import ApplyFilterButton from "../../../utils/components/applyFilterButton/Apply
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import Loader from "../../../utils/components/Loader";
 import Seo from "../../../components/Seo/Seo";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 class AllCommunities extends React.Component {
   constructor(props) {
@@ -278,9 +279,9 @@ class AllCommunities extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
       count: metaData && metaData.count,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       onRowsDelete: (rowsDeleted) => {
         const idsToDelete = rowsDeleted.data;
         toggleDeleteConfirmation({

--- a/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/AllEvents.js
@@ -34,7 +34,7 @@ import { PAGE_PROPERTIES } from "../ME  Tools/MEConstants";
 import { getAdminApiEndpoint, getLimit, handleFilterChange, onTableStateChange } from "../../../utils/helpers";
 import ApplyFilterButton from "../../../utils/components/applyFilterButton/ApplyFilterButton";
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
-import { FROM } from "../../../utils/constants";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS, FROM } from '../../../utils/constants';
 import Loader from "../../../utils/components/Loader";
 import Seo from "../../../components/Seo/Seo";
 import CustomOptions from "../ME  Tools/table /CustomOptions";
@@ -575,9 +575,9 @@ class AllEvents extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
       count: metaData && metaData.count,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       onTableChange: (action, tableState) =>
         onTableStateChange({

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventRSVPs.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventRSVPs.js
@@ -19,6 +19,7 @@ import styles from "../../../components/Widget/widget-jss";
 import { apiCall } from "../../../utils/messenger";
 import { Paper } from "@mui/material";
 import Seo from "../../../components/Seo/Seo";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 function TabContainer(props) {
   const { children } = props;
@@ -133,8 +134,8 @@ class EventRSVPs extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       onRowsDelete: (rowsDeleted) => {
         const idsToDelete = rowsDeleted.data;
         idsToDelete.forEach((d) => {

--- a/app/containers/MassEnergizeSuperAdmin/Events/EventsFromOtherCommunities.js
+++ b/app/containers/MassEnergizeSuperAdmin/Events/EventsFromOtherCommunities.js
@@ -17,6 +17,7 @@ import { getLimit, handleFilterChange, onTableStateChange } from "../../../utils
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import ApplyFilterButton from "../../../utils/components/applyFilterButton/ApplyFilterButton";
 import Seo from "../../../components/Seo/Seo";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 function EventsFromOtherCommunities({
   putOtherEventsInRedux,
@@ -174,8 +175,8 @@ const ids = (communities || []).map((it) => it.id);
     filterType: "dropdown",
     responsive: "standard",
     print: true,
-    rowsPerPage: 25,
-    rowsPerPageOptions: [10, 25, 100],
+    rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+    rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
     selectableRows: false,
     count: metaData && metaData.count,
     confirmFilters: true,

--- a/app/containers/MassEnergizeSuperAdmin/Feature Flags/ManageFeatureFlags.js
+++ b/app/containers/MassEnergizeSuperAdmin/Feature Flags/ManageFeatureFlags.js
@@ -9,7 +9,7 @@ import Loading from "dan-components/Loading";
 import { Link } from "react-router-dom";
 import { Paper, Typography } from "@mui/material";
 import { apiCall } from "../../../utils/messenger";
-import { LOADING } from "../../../utils/constants";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS, LOADING } from '../../../utils/constants';
 import ThemeModal from "../../../components/Widget/ThemeModal";
 import ListingComponent from "./ListingComponent";
 const hasExpired = (date) => {
@@ -239,8 +239,8 @@ function ManageFeatureFlags({
     responsive: "standard",
     download: false,
     print: false,
-    rowsPerPage: 25,
-    rowsPerPageOptions: [50, 100],
+    rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+    rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
     onRowsDelete: (rowsDeleted) => {
       const idsToDelete = rowsDeleted.data;
       toggleDeleteConfirmation({

--- a/app/containers/MassEnergizeSuperAdmin/Goals/AllGoals.js
+++ b/app/containers/MassEnergizeSuperAdmin/Goals/AllGoals.js
@@ -17,6 +17,7 @@ import { apiCall } from '../../../utils/messenger';
 import styles from '../../../components/Widget/widget-jss';
 import { reduxGetAllGoals, reduxGetAllCommunityGoals, reduxToggleUniversalToast } from '../../../redux/redux-actions/adminActions';
 import CommunitySwitch from '../Summary/CommunitySwitch';
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 class AllGoals extends React.Component {
   constructor(props) {
@@ -186,8 +187,8 @@ class AllGoals extends React.Component {
       filterType: 'dropdown',
       responsive: 'stacked',
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       page: 1,
       indexColumn: 'id',
       onRowsDelete: (rowsDeleted) => {

--- a/app/containers/MassEnergizeSuperAdmin/Messages/CommunityAdminMessages.js
+++ b/app/containers/MassEnergizeSuperAdmin/Messages/CommunityAdminMessages.js
@@ -41,6 +41,7 @@ import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 import { renderInvisibleChips } from "../ME  Tools/table /utils";
 import Seo from "../../../../app/components/Seo/Seo";
 import CustomOptions from "../ME  Tools/table /CustomOptions";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 export const replyToMessage = ({ pathname, props, transfer }) => {
   // const pathname = `/admin/edit/${id}/message`;
@@ -348,8 +349,8 @@ class AllCommunityAdminMessages extends React.Component {
       responsive: "standard",
       count: metaData && metaData.count,
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       onTableChange: (action, tableState) =>
         onTableStateChange({

--- a/app/containers/MassEnergizeSuperAdmin/Messages/ScheduledMessages.js
+++ b/app/containers/MassEnergizeSuperAdmin/Messages/ScheduledMessages.js
@@ -15,7 +15,7 @@ import {
 import EditIcon from "@mui/icons-material/Edit";
 import { Typography } from "@mui/material";
 import { reduxLoadMetaDataAction, reduxLoadScheduledMessages, reduxToggleUniversalModal, reduxToggleUniversalToast } from "../../../redux/redux-actions/adminActions";
-import { LOADING } from "../../../utils/constants";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS, LOADING } from '../../../utils/constants';
 import Loading from "dan-components/Loading";
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import { onTableStateChange } from "../../../utils/helpers";
@@ -159,8 +159,8 @@ function ScheduledMessages({
     count:meta?.scheduledMessages?.count,
     download: false,
     print: false,
-    rowsPerPage: 10,
-    rowsPerPageOptions: [10, 25, 50, 100],
+    rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+    rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
     onRowsDelete: (rowsDeleted) => {
       const idsToDelete = rowsDeleted.data;
       toggleDeleteConfirmation({

--- a/app/containers/MassEnergizeSuperAdmin/Messages/TeamAdminMessages.js
+++ b/app/containers/MassEnergizeSuperAdmin/Messages/TeamAdminMessages.js
@@ -40,6 +40,7 @@ import Loader from "../../../utils/components/Loader";
 import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 import Seo from "../../../components/Seo/Seo";
 import CustomOptions from "../ME  Tools/table /CustomOptions";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 class AllTeamAdminMessages extends React.Component {
   constructor(props) {
     super(props);
@@ -304,8 +305,8 @@ class AllTeamAdminMessages extends React.Component {
       responsive: "standard",
       count: metaData && metaData.count,
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       onTableChange: (action, tableState) =>
         onTableStateChange({

--- a/app/containers/MassEnergizeSuperAdmin/Pages/ActionEngagements.js
+++ b/app/containers/MassEnergizeSuperAdmin/Pages/ActionEngagements.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
-import { LOADING } from "../../../utils/constants";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS, LOADING } from '../../../utils/constants';
 import { PAGE_PROPERTIES } from "../ME  Tools/MEConstants";
 import METable from "../ME  Tools/table /METable";
 import Loading from "dan-components/Loading";
@@ -133,8 +133,8 @@ function ActionEngagements({ engagements, putItemsInRedux }) {
     filterType: "dropdown",
     responsive: "standard",
     print: true,
-    rowsPerPage: 25,
-    rowsPerPageOptions: [10, 25, 100],
+    rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+    rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
   };
   data = fashionData(data);
   //   ----------------------------------------------------

--- a/app/containers/MassEnergizeSuperAdmin/Policies/AllPolicies.js
+++ b/app/containers/MassEnergizeSuperAdmin/Policies/AllPolicies.js
@@ -21,6 +21,7 @@ import {
 import { Typography } from "@mui/material";
 import { ArrowRight, ArrowRightAlt } from "@mui/icons-material";
 import Seo from "../../../components/Seo/Seo";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 class AllPolicies extends React.Component {
   constructor(props) {
     super(props);
@@ -159,8 +160,8 @@ class AllPolicies extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       page: 1,
       indexColumn: "id",
       onRowsDelete: (rowsDeleted) => {

--- a/app/containers/MassEnergizeSuperAdmin/Subscribers/AllSubscribers.js
+++ b/app/containers/MassEnergizeSuperAdmin/Subscribers/AllSubscribers.js
@@ -25,6 +25,7 @@ import { isEmpty } from "../../../utils/common";
 import Loader from "../../../utils/components/Loader";
 import Seo from "../../../components/Seo/Seo";
 import CustomOptions from "../ME  Tools/table /CustomOptions";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 class AllSubscribers extends React.Component {
   constructor(props) {
@@ -212,8 +213,8 @@ class AllSubscribers extends React.Component {
       responsive: "standard",
       print: true,
       count: metaData && metaData.count,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       customSearchRender: (searchText, handleSearch, hideSearch, options) => (
         <SearchBar

--- a/app/containers/MassEnergizeSuperAdmin/Tasks/AllTasks.js
+++ b/app/containers/MassEnergizeSuperAdmin/Tasks/AllTasks.js
@@ -19,6 +19,7 @@ import PauseOutlinedIcon from "@mui/icons-material/PauseOutlined";
 import PlayArrowOutlinedIcon from "@mui/icons-material/PlayArrowOutlined";
 import { Link } from "react-router-dom";
 import Seo from "../../../components/Seo/Seo";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 class AllTasks extends React.Component {
   constructor(props) {
     super(props);
@@ -269,8 +270,8 @@ class AllTasks extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 30,
-
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       onRowsDelete: (rowsDeleted) => {
         const idsToDelete = rowsDeleted.data;
         this.props.toggleDeleteConfirmation({

--- a/app/containers/MassEnergizeSuperAdmin/Teams/AllTeams.js
+++ b/app/containers/MassEnergizeSuperAdmin/Teams/AllTeams.js
@@ -51,6 +51,7 @@ import { getData } from "../Messages/CommunityAdminMessages";
 import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 import Seo from "../../../../app/components/Seo/Seo";
 import CustomOptions from "../ME  Tools/table /CustomOptions";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 class AllTeams extends React.Component {
   constructor(props) {
@@ -406,9 +407,9 @@ class AllTeams extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
       count: metaData && metaData.count,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       onTableChange: (action, tableState) =>
         onTableStateChange({

--- a/app/containers/MassEnergizeSuperAdmin/Teams/TeamMembers.js
+++ b/app/containers/MassEnergizeSuperAdmin/Teams/TeamMembers.js
@@ -30,6 +30,7 @@ import METable from "../ME  Tools/table /METable";
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import { getLimit } from "../../../utils/helpers";
 import Seo from "../../../components/Seo/Seo";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 function TabContainer(props) {
   const { children } = props;
@@ -261,8 +262,8 @@ class TeamMembers extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       // count: metaData && metaData.count,
       // confirmFilters: true,
       onRowsDelete: (rowsDeleted) => {

--- a/app/containers/MassEnergizeSuperAdmin/Testimonials/AllTestimonials.js
+++ b/app/containers/MassEnergizeSuperAdmin/Testimonials/AllTestimonials.js
@@ -47,6 +47,7 @@ import { getData } from "../Messages/CommunityAdminMessages";
 import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 import Seo from "../../../components/Seo/Seo";
 import CustomOptions from "../ME  Tools/table /CustomOptions";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 class AllTestimonials extends React.Component {
   constructor(props) {
@@ -440,8 +441,8 @@ class AllTestimonials extends React.Component {
       responsive: "standard",
       count: metaData && metaData.count,
       print: true,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       customSearchRender: (searchText, handleSearch, hideSearch, options) => (
         <SearchBar

--- a/app/containers/MassEnergizeSuperAdmin/Users/AllUsers.js
+++ b/app/containers/MassEnergizeSuperAdmin/Users/AllUsers.js
@@ -46,6 +46,7 @@ import { getData } from "../Messages/CommunityAdminMessages";
 import MEPaperBlock from "../ME  Tools/paper block/MEPaperBlock";
 import Seo from "../../../components/Seo/Seo";
 import CustomOptions from "../ME  Tools/table /CustomOptions";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 class AllUsers extends React.Component {
   constructor(props) {
@@ -372,8 +373,8 @@ class AllUsers extends React.Component {
       customSort: this.customSort,
       print: true,
       count: metaData && metaData.count,
-      rowsPerPage: 25,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       // When there is time, we need to think of a way to implement this in MEDatatable itself, so we dont have to repeat this
       onTableChange: (action, tableState) =>

--- a/app/containers/MassEnergizeSuperAdmin/Vendors/AllVendors.js
+++ b/app/containers/MassEnergizeSuperAdmin/Vendors/AllVendors.js
@@ -36,6 +36,7 @@ import ApplyFilterButton from "../../../utils/components/applyFilterButton/Apply
 import SearchBar from "../../../utils/components/searchBar/SearchBar";
 import Loader from "../../../utils/components/Loader";
 import Seo from "../../../components/Seo/Seo";
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_ITEMS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 class AllVendors extends React.Component {
   constructor(props) {
@@ -250,9 +251,9 @@ class AllVendors extends React.Component {
       filterType: "dropdown",
       responsive: "standard",
       print: true,
-      rowsPerPage: 25,
+      rowsPerPage: DEFAULT_ITEMS_PER_PAGE,
       count: metaData && metaData.count,
-      rowsPerPageOptions: [10, 25, 100],
+      rowsPerPageOptions: DEFAULT_ITEMS_PER_PAGE_OPTIONS,
       confirmFilters: true,
       onTableChange: (action, tableState) =>
         onTableStateChange({

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -15,3 +15,6 @@ export const FROM = {
   MAIN_EVENTS: "main",
   OTHER_EVENTS: "others",
 };
+
+export const DEFAULT_ITEMS_PER_PAGE = 25;
+export const DEFAULT_ITEMS_PER_PAGE_OPTIONS = [10, 25, 50, 100];

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -1,5 +1,6 @@
 import { IS_CANARY, IS_LOCAL, IS_PROD } from "../config/constants";
 import { apiCall } from "./messenger";
+import { DEFAULT_ITEMS_PER_PAGE } from './constants';
 const TABLE_PROPERTIES = "_TABLE_PROPERTIES";
 const FILTERS = "_FILTERS";
 
@@ -11,7 +12,7 @@ export const getSearchText = (key) => {
 export const getLimit = (key) => {
   var tableProp = localStorage.getItem(key + TABLE_PROPERTIES);
   tableProp = JSON.parse(tableProp || null) || {};
-  return (tableProp && tableProp.rowsPerPage) || 50;
+  return (tableProp && tableProp.rowsPerPage) || DEFAULT_ITEMS_PER_PAGE;
 };
 export const getFilterParamsFromLocalStorage = (key) => {
   var tableProp = localStorage.getItem("MAIN_FILTER_OBJECT");


### PR DESCRIPTION
####  Summary / Highlights
This pull request fixes the issue with paginated data not fetching after 100 items. It also updates the default items per page in various components to use the constant value defined in the utils/constants file.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
